### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   TagBot:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/randyzwitch/ECharts.jl/security/code-scanning/1](https://github.com/randyzwitch/ECharts.jl/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` section that scopes what the `GITHUB_TOKEN` is allowed to do, instead of relying on repository or organization defaults. For a tagging/bot workflow like this, TagBot primarily needs read access to the repository contents; in many setups it does not need to push code or create releases via `GITHUB_TOKEN`. A safe minimal starting point that satisfies CodeQL and GitHub guidance is to set `contents: read` at the workflow or job level.

The best fix here, without changing existing functionality, is to add a `permissions` block at the job level under `jobs: TagBot:` so it only affects this job. We’ll add:

```yaml
permissions:
  contents: read
```

This constrains `GITHUB_TOKEN` to read repository contents while leaving the rest of the workflow unchanged. No new methods, imports, or additional definitions are needed—this is purely a YAML configuration change in `.github/workflows/TagBot.yml`, inserted between `runs-on: ubuntu-latest` and `steps:` (or as another job key at the same indentation level as `runs-on` and `steps`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
