### PR TITLE
Add EChartRaw, echart(), and @echart macro for raw JSON chart specs

### DIFF
--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -12,7 +12,7 @@ module ECharts
 	const colorpalettes = merge(ColorBrewer.colorSchemes, NoveltyColors.ColorDict)
 	export colorpalettes
 
-	export EChart
+	export EChart, EChartRaw, echart, @echart
 	export BoxPlotSeries, CandleStickSeries, EffectScatterSeries, FunnelSeries, GaugeSeries, GraphSeries,
 	HeatmapSeries, LinesSeries, MapSeries, ParallelSeries, PictorialBarSeries, PieSeries, RadarSeries,
 	SankeySeries, SunburstSeries, ThemeRiverSeries, TreeSeries, TreemapSeries, XYSeries

--- a/src/render.jl
+++ b/src/render.jl
@@ -1,5 +1,72 @@
+"""
+    EChartRaw
+
+An ECharts chart created from a raw JSON string specification. Produced by [`echart`](@ref)
+or the [`@echart`](@ref) macro. Renders directly in Jupyter notebooks and the VSCode Julia
+plot panel.
+
+# Fields
+- `option`: raw JSON string passed to ECharts `setOption`
+- `ec_width`: chart width in pixels
+- `ec_height`: chart height in pixels
+- `ec_renderer`: ECharts renderer (`"canvas"` or `"svg"`)
+- `theme`: ECharts [`Theme`](@ref)
+"""
+mutable struct EChartRaw
+    option::String
+    ec_width::Int
+    ec_height::Int
+    ec_renderer::String
+    theme::Theme
+end
+
+"""
+    echart(option::AbstractString; width::Int=800, height::Int=450, renderer::String="canvas", theme::Theme=roma)
+
+Create an `EChartRaw` from a raw JSON string specification, allowing ECharts examples copied
+from the Apache ECharts gallery to be rendered directly in Julia.
+
+# Example
+```julia
+ec = echart(\"\"\"
+{
+  "xAxis": {"type": "category", "data": ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]},
+  "yAxis": {"type": "value"},
+  "series": [{"data": [820, 932, 901, 934, 1290, 1330, 1320], "type": "bar"}]
+}
+\"\"\")
+```
+"""
+function echart(option::AbstractString; width::Int=800, height::Int=450,
+                renderer::String="canvas", theme::Theme=roma)
+    JSON.parse(option)  # validate; throws ParseError on invalid JSON
+    return EChartRaw(String(option), width, height, renderer, theme)
+end
+
+"""
+    @echart json_string
+    @echart(json_string, width=800, height=450, renderer="canvas", theme=roma)
+
+Macro form of [`echart`](@ref). Accepts a raw JSON string literal without a function-call wrapper.
+
+# Example
+```julia
+@echart \"\"\"
+{
+  "xAxis": {"type": "category", "data": ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]},
+  "yAxis": {"type": "value"},
+  "series": [{"data": [820, 932, 901, 934, 1290, 1330, 1320], "type": "bar"}]
+}
+\"\"\"
+```
+"""
+macro echart(option, kwargs...)
+    :(echart($(esc(option)); $(map(esc, kwargs)...)))
+end
+
 #Pretty-print
 print(x::EChart) = print(json(makevalidjson(x)))
+print(x::EChartRaw) = print(x.option)
 
 #Shared helper: produces self-contained HTML with echarts.min.js inlined
 function _echarts_html(ec::EChart)
@@ -35,3 +102,32 @@ Base.show(io::IO, ::MIME"text/html", ec::EChart) = write(io, _echarts_html(ec))
 
 #VSCode method - displays chart inline in the VSCode plot panel (requires Julia VSCode extension)
 Base.show(io::IO, ::MIME"juliavscode/html", ec::EChart) = write(io, _echarts_html(ec))
+
+#Shared helper for EChartRaw: same structure as EChart but uses the raw JSON option string directly
+function _echarts_html(ec::EChartRaw)
+    theme = json(makevalidjson(ec.theme))
+    chart_id = "echarts_" * string(rand(UInt32))
+
+    echarts_loader = if get(ENV, "ECHARTS_DOCS_BUILD", "false") == "true"
+        ""
+    else
+        echarts_js = read(joinpath(@__DIR__, "echarts.min.js"), String)
+        "if (typeof echarts === 'undefined') { $(echarts_js) }"
+    end
+
+    return """
+    <div id="$(chart_id)" style="width:$(ec.ec_width)px;height:$(ec.ec_height)px;"></div>
+    <script>
+    $(echarts_loader)
+    (function() {
+        var dom = document.getElementById('$(chart_id)');
+        var myChart = echarts.init(dom, $(theme), {renderer: '$(ec.ec_renderer)'});
+        myChart.setOption($(ec.option));
+        window.addEventListener('resize', function() { myChart.resize(); });
+    })();
+    </script>
+    """
+end
+
+Base.show(io::IO, ::MIME"text/html", ec::EChartRaw) = write(io, _echarts_html(ec))
+Base.show(io::IO, ::MIME"juliavscode/html", ec::EChartRaw) = write(io, _echarts_html(ec))

--- a/test/render.jl
+++ b/test/render.jl
@@ -3,3 +3,36 @@
 @test ECharts.makevalidjson([:hello, :world]) == ["hello", "world"]
 @test ECharts.makevalidjson(missing) == "-"
 @test ECharts.makevalidjson(4//7) == 4//7
+
+# echart() / EChartRaw
+let valid_json = """{"xAxis":{"type":"category","data":["Mon","Tue"]},"yAxis":{"type":"value"},"series":[{"data":[820,932],"type":"bar"}]}"""
+    ec = echart(valid_json)
+    @test ec isa EChartRaw
+    @test ec.ec_width == 800
+    @test ec.ec_height == 450
+    @test ec.ec_renderer == "canvas"
+    @test ec.option == valid_json
+
+    # keyword overrides
+    ec2 = echart(valid_json; width=1200, height=600, renderer="svg")
+    @test ec2.ec_width == 1200
+    @test ec2.ec_height == 600
+    @test ec2.ec_renderer == "svg"
+
+    # invalid JSON throws
+    @test_throws Exception echart("{not valid json}")
+
+    # HTML output contains the option and chart div
+    html = repr(MIME"text/html"(), ec)
+    @test occursin(valid_json, html)
+    @test occursin("echarts.init", html)
+
+    # @echart macro produces the same result as echart()
+    ec3 = @echart valid_json
+    @test ec3 isa EChartRaw
+    @test ec3.option == valid_json
+
+    ec4 = @echart(valid_json, width=1200, height=600)
+    @test ec4.ec_width == 1200
+    @test ec4.ec_height == 600
+end


### PR DESCRIPTION
## Summary

- Adds `EChartRaw` struct, `echart()` function, and `@echart` macro so users can render Apache ECharts examples directly in Julia using a raw JSON option string
- Exports `EChartRaw`, `echart`, and `@echart` from the module
- Adds `Base.show` for `text/html` and `juliavscode/html` MIME types so charts render in Jupyter and VSCode
- Adds docstrings for `EChartRaw`, `echart`, and `@echart`
- Adds test coverage in `test/render.jl`

## Test plan

- [ ] Run `test/render.jl` — all `echart`/`EChartRaw`/`@echart` tests pass
- [ ] Verify invalid JSON throws a `ParseError`
- [ ] Verify HTML output contains `echarts.init` and the option string

🤖 Generated with [Claude Code](https://claude.com/claude-code)