### PR TITLE
Fix jitter! corrupting wrong series when series != 1

### DIFF
--- a/src/chartopts/jitter.jl
+++ b/src/chartopts/jitter.jl
@@ -45,9 +45,9 @@ function jitter!(ec::EChart, series::Int; pctxrange::Real = 0.05, pctyrange::Rea
     yrange = maximum(_y) - minimum(_y)
 
     #To avoid inexact error, ensure array is float
-    ec.series[series].data isa Vector{Vector{Int64}} ?
-        ec.series[1].data = [convert(Vector{Float64}, x) for x in ec.series[series].data] :
-            nothing
+    if ec.series[series].data isa Vector{Vector{Int64}}
+        ec.series[series].data = [convert(Vector{Float64}, x) for x in ec.series[series].data]
+    end
 
     #Iterate over series to jitter dataset
     for datum in ec.series[series].data


### PR DESCRIPTION
## Summary

- `ec.series[1]` was hardcoded on line 49 of `jitter.jl` instead of `ec.series[series]`
- When calling `jitter!(ec, 2)` (or any series index other than 1), the function would read data from the correct series but write the float-converted result into series 1, silently corrupting it
- Fixed by using `ec.series[series]` consistently on both sides of the assignment

## Test plan

- [ ] Call `jitter!` on a multi-series scatter chart with `series = 2` and verify series 1 is unchanged and series 2 is jittered
- [ ] Verify the all-series `jitter!(ec)` method still applies jitter to every series correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)