### PR TITLE
Fix corrplot silently mutating the caller's matrix

### DIFF
--- a/src/plots/corrplot.jl
+++ b/src/plots/corrplot.jl
@@ -30,7 +30,7 @@ function corrplot(m::Matrix;
     size(m)[1] != size(m)[2] ? error("Matrix needs to be square for a corrplot") : nothing
 
     #Copy to avoid mutating
-    m_ = m
+    m_ = copy(m)
     if layout == "lower"
         tril!(m_)
     elseif layout == "upper"


### PR DESCRIPTION
## Summary

- `m_ = m` on line 33 of `corrplot.jl` is a reference alias, not a copy — both names point to the same matrix in memory
- Calling `tril!(m_)` or `triu!(m_)` (in-place operations) therefore mutated the matrix the caller passed in, with no warning
- The comment directly above already said `#Copy to avoid mutating`, so the intent was always correct — the copy just wasn't actually happening
- Fixed with `m_ = copy(m)`

## Test plan

- [ ] Call `corrplot` with `layout = "lower"` and verify the original matrix passed in is unchanged afterward
- [ ] Same for `layout = "upper"`
- [ ] Verify the rendered chart is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)