### PR TITLE
Guard against nil legend in seriesnames! before updating legend data

### DIFF
--- a/src/chartopts/seriesnames.jl
+++ b/src/chartopts/seriesnames.jl
@@ -49,8 +49,8 @@ function seriesnames!(ec::EChart, names::AbstractVector{String})
         ec.series[i].name = names[i]
     end
 
-    #Modify legend attribute to use new seriesnames
-    ec.legend.data = names
+    #Modify legend attribute to use new seriesnames, if one exists
+    isnothing(ec.legend) || (ec.legend.data = names)
 
     return ec
 


### PR DESCRIPTION
## Summary

- `seriesnames!(ec, names)` unconditionally wrote to `ec.legend.data` after updating series names
- `ec.legend` is `nothing` by default and only set when `legend!(ec)` is called — so calling `seriesnames!` without a prior `legend!` threw an unhelpful `FieldError` deep inside the function
- The legend is optional, so the update is now skipped when `ec.legend` is `nothing`

## Test plan

- [ ] Call `seriesnames!(ec, names)` on a chart where `legend!` has **not** been called and confirm no error is thrown
- [ ] Call `seriesnames!(ec, names)` on a chart where `legend!` **has** been called and confirm `ec.legend.data` is updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)