### PR TITLE
Validate size length in bubble before zipping with x/y data

### DIFF
--- a/src/plots/bubble.jl
+++ b/src/plots/bubble.jl
@@ -42,7 +42,12 @@ function bubble(x::AbstractVector{<:Union{Missing, Real}},
 					kwargs...)
 
 		#Append size into existing data structure
-		[push!(x, y) for (x,y) in zip(ec.series[1].data, size)]
+		npoints = length(ec.series[1].data)
+		length(size) != npoints &&
+			error("bubble: x/y data has $npoints points but size has $(length(size)) — all three must have equal length")
+		for (point, sz) in zip(ec.series[1].data, size)
+			push!(point, sz)
+		end
 
 		normalized = maximum(sqrt.(size))
 


### PR DESCRIPTION
## Summary

- `zip` silently stops at the shorter sequence, so passing a `size` vector with fewer elements than `x`/`y` would produce a bubble chart with some points missing their size dimension — no error, no warning
- Now errors immediately before the zip with a message showing both lengths, making the mismatch obvious
- Also replaced a list-comprehension-for-side-effects with a plain `for` loop, which better expresses intent

## Test plan

- [ ] Call `bubble(x, y, size)` with `length(size) < length(x)` and confirm the new descriptive error is raised
- [ ] Call `bubble(x, y, size)` with matching lengths and confirm the chart renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)