### PR TITLE
Add guards to legend! before accessing magic indices in series data

### DIFF
--- a/src/chartopts/legend.jl
+++ b/src/chartopts/legend.jl
@@ -30,9 +30,17 @@ function legend!(ec::EChart; kwargs...)
 	#Define data upfront for the most common cases
 	#This currently clobbers, should this be a check for nothing instead of clobber?
 	if ec.ec_charttype in ["circular", "funnel"]
-		ec.legend = Legend(data = [x["name"] for x in ec.series[1].data])
+		data = ec.series[1].data
+		isempty(data) && error("Cannot build legend: $(ec.ec_charttype) series data is empty")
+		all(d -> haskey(d, "name"), data) ||
+			error("Cannot build legend: $(ec.ec_charttype) series data entries must each have a \"name\" key")
+		ec.legend = Legend(data = [x["name"] for x in data])
 	elseif ec.ec_charttype in ["streamgraph"]
-		ec.legend = Legend(data = unique([x[3] for x in ec.series[1].data]))
+		data = ec.series[1].data
+		isempty(data) && error("Cannot build legend: streamgraph series data is empty")
+		all(d -> length(d) >= 3, data) ||
+			error("Cannot build legend: streamgraph series data entries must each have at least 3 elements (got an entry with $(minimum(length.(data))))")
+		ec.legend = Legend(data = unique([x[3] for x in data]))
 	else
 		ec.legend = Legend(data = [x.name for x in ec.series])
 	end


### PR DESCRIPTION
## Summary

- For `circular`/`funnel` charts, `legend!` accessed `x["name"]` on every data dict with no check that the key exists — a missing key produced a cryptic `KeyError`
- For `streamgraph`, it accessed `x[3]` with no check that the element had ≥ 3 entries — a short element produced a cryptic `BoundsError`
- Neither error message indicated which chart type caused the problem or what the data was expected to look like
- Now validates that data is non-empty and has the expected shape before indexing, with descriptive error messages in both cases

## Test plan

- [ ] Call `legend!` on a circular/funnel chart with well-formed data and confirm it works as before
- [ ] Call `legend!` on a circular/funnel chart with data dicts missing the `"name"` key and confirm the new descriptive error is raised
- [ ] Call `legend!` on a streamgraph with well-formed data and confirm it works as before
- [ ] Call `legend!` on a streamgraph with short data entries and confirm the new descriptive error is raised

🤖 Generated with [Claude Code](https://claude.com/claude-code)