### PR TITLE
Add axis::Int parameter to xaxis!, yaxis!, xgridlines!, ygridlines!

### DIFF
--- a/src/chartopts/gridlines.jl
+++ b/src/chartopts/gridlines.jl
@@ -9,6 +9,7 @@ xgridlines!(ec::EChart; show, interval, kwargs...)
 ```
 
 ## Arguments
+* `axis::Int = 1` : index of the x-axis to modify (for multi-axis charts)
 * `show::Bool = true` : display grid lines
 * `interval::Union{Int, String, JSON.JSONText, Nothing} = "auto"` : interval between grid lines
 * `kwargs` : additional `LineStyle` fields (e.g. `color`, `width`, `type`)
@@ -19,19 +20,20 @@ b = bar(["A","B","C"], [1,2,3])
 xgridlines!(b, show = false)
 ```
 """
-function xgridlines!(ec::EChart; show::Bool = true,
+function xgridlines!(ec::EChart; axis::Int = 1,
+								 show::Bool = true,
 								 interval::Union{Int, String, JSON.JSONText, Nothing} = "auto",
 								 kwargs...)
 
 	#Set if not present
-    isnothing(ec.xAxis[1].splitLine) ? ec.xAxis[1].splitLine = SplitLine() : nothing
+    isnothing(ec.xAxis[axis].splitLine) ? ec.xAxis[axis].splitLine = SplitLine() : nothing
 
 	#Set top-level properties
-    ec.xAxis[1].splitLine.show = show
-	ec.xAxis[1].splitLine.interval = interval
+    ec.xAxis[axis].splitLine.show = show
+	ec.xAxis[axis].splitLine.interval = interval
 
 	#kwargs all the lineStyle arguments
-	length(kwargs) > 0 ? for (k, v) in kwargs setfield!(ec.xAxis[1].splitLine.lineStyle, k, v) end : nothing
+	length(kwargs) > 0 ? for (k, v) in kwargs setfield!(ec.xAxis[axis].splitLine.lineStyle, k, v) end : nothing
 
     return ec
 
@@ -48,6 +50,7 @@ ygridlines!(ec::EChart; show, interval, kwargs...)
 ```
 
 ## Arguments
+* `axis::Int = 1` : index of the y-axis to modify (for multi-axis charts)
 * `show::Bool = true` : display grid lines
 * `interval::Union{Int, String, JSON.JSONText, Nothing} = "auto"` : interval between grid lines
 * `kwargs` : additional `LineStyle` fields (e.g. `color`, `width`, `type`)
@@ -58,19 +61,20 @@ b = bar(["A","B","C"], [1,2,3])
 ygridlines!(b, show = false)
 ```
 """
-function ygridlines!(ec::EChart; show::Bool = true,
+function ygridlines!(ec::EChart; axis::Int = 1,
+								 show::Bool = true,
 								 interval::Union{Int, String, JSON.JSONText, Nothing} = "auto",
 								 kwargs...)
 
 	#Set if not present
-    isnothing(ec.yAxis[1].splitLine) ? ec.yAxis[1].splitLine = SplitLine() : nothing
+    isnothing(ec.yAxis[axis].splitLine) ? ec.yAxis[axis].splitLine = SplitLine() : nothing
 
 	#Set top-level properties
-    ec.yAxis[1].splitLine.show = show
-	ec.yAxis[1].splitLine.interval = interval
+    ec.yAxis[axis].splitLine.show = show
+	ec.yAxis[axis].splitLine.interval = interval
 
 	#kwargs all the lineStyle arguments
-	length(kwargs) > 0 ? for (k, v) in kwargs setfield!(ec.yAxis[1].splitLine.lineStyle, k, v) end : nothing
+	length(kwargs) > 0 ? for (k, v) in kwargs setfield!(ec.yAxis[axis].splitLine.lineStyle, k, v) end : nothing
 
     return ec
 

--- a/src/chartopts/xyaxis.jl
+++ b/src/chartopts/xyaxis.jl
@@ -9,6 +9,7 @@ yaxis!(ec::EChart; formatter, kwargs...)
 ```
 
 ## Arguments
+* `axis::Int = 1` : index of the y-axis to modify (for multi-axis charts)
 * `formatter::Union{String, JSON.JSONText, Nothing} = nothing` : axis label format string or JS function
 * `kwargs` : any field of the `YAxis` struct (e.g. `name`, `min`, `max`, `type`)
 
@@ -18,14 +19,14 @@ b = bar(["A","B","C"], [1000, 2000, 3000])
 yaxis!(b, name = "Revenue", formatter = "\${value}")
 ```
 """
-function yaxis!(ec::EChart; formatter::Union{String, JSON.JSONText, Nothing} = nothing, kwargs...)
+function yaxis!(ec::EChart; axis::Int = 1, formatter::Union{String, JSON.JSONText, Nothing} = nothing, kwargs...)
 
 	for (k, v) in kwargs
-	   setfield!(ec.yAxis[1], k, v)
+	   setfield!(ec.yAxis[axis], k, v)
 	end
 
 	#Apply axis label format if present
-	!isnothing(formatter) ? ec.yAxis[1].axisLabel.formatter = formatter : nothing
+	!isnothing(formatter) ? ec.yAxis[axis].axisLabel.formatter = formatter : nothing
 
 	return ec
 
@@ -42,6 +43,7 @@ xaxis!(ec::EChart; formatter, kwargs...)
 ```
 
 ## Arguments
+* `axis::Int = 1` : index of the x-axis to modify (for multi-axis charts)
 * `formatter::Union{String, JSON.JSONText, Nothing} = nothing` : axis label format string or JS function
 * `kwargs` : any field of the `XAxis` struct (e.g. `name`, `type`, `boundaryGap`)
 
@@ -51,14 +53,14 @@ b = bar(["A","B","C"], [1,2,3])
 xaxis!(b, name = "Category")
 ```
 """
-function xaxis!(ec::EChart; formatter::Union{String, JSON.JSONText, Nothing} = nothing, kwargs...)
+function xaxis!(ec::EChart; axis::Int = 1, formatter::Union{String, JSON.JSONText, Nothing} = nothing, kwargs...)
 
 	for (k, v) in kwargs
-	   setfield!(ec.xAxis[1], k, v)
+	   setfield!(ec.xAxis[axis], k, v)
 	end
 
 	#Apply axis label format if present
-	!isnothing(formatter) ? ec.xAxis[1].axisLabel.formatter = formatter : nothing
+	!isnothing(formatter) ? ec.xAxis[axis].axisLabel.formatter = formatter : nothing
 
 	return ec
 


### PR DESCRIPTION
## Summary

All four axis helper functions hardcoded `[1]` when accessing `ec.xAxis` / `ec.yAxis`, making it impossible to configure a secondary axis on multi-axis charts. Passing `name`, `min`, `max`, or grid line styles to any axis other than the first required bypassing these helpers entirely and mutating the struct directly.

Added `axis::Int = 1` to each function signature. The default of `1` preserves all existing behaviour. Docstrings updated accordingly.

## Test plan

- [ ] `yaxis!(ec, name = "Revenue")` still works as before (axis 1)
- [ ] `yaxis!(ec, axis = 2, name = "Volume")` correctly targets the second y-axis on a dual-axis chart
- [ ] Same for `xaxis!`, `xgridlines!`, `ygridlines!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)