### PR TITLE
Replace side-effect list comprehensions with for loops in smooth!

### DIFF
--- a/src/chartopts/smooth.jl
+++ b/src/chartopts/smooth.jl
@@ -28,7 +28,9 @@ smooth!(l)
 function smooth!(ec::EChart; smooth::Bool = true)
 	#All series by default
 
-	[x.smooth = smooth for x in ec.series]
+	for s in ec.series
+		s.smooth = smooth
+	end
 
 	return ec
 
@@ -56,7 +58,9 @@ See the primary `smooth!` method for full argument documentation.
 """
 function smooth!(ec::EChart, series::Vector{Int}; smooth::Bool = true)
 
-	[smooth!(ec, x, smooth = smooth) for x in series]
+	for s in series
+		smooth!(ec, s, smooth = smooth)
+	end
 
 	return ec
 


### PR DESCRIPTION
## Summary

- Two list comprehensions in `smooth!` existed purely for their side effects (mutating series fields / calling a function), with the resulting array thrown away immediately
- Using comprehensions for side effects allocates an unnecessary temporary array and obscures intent — a `for` loop is the right construct
- Replaced both occurrences with plain `for` loops

## Test plan

- [ ] Call `smooth!(ec)` and confirm all series have `smooth = true`
- [ ] Call `smooth!(ec, [1, 3])` and confirm only series 1 and 3 are smoothed

🤖 Generated with [Claude Code](https://claude.com/claude-code)