### PR TITLE
Promote hardcoded chart-type lists to module-level constants

### DIFF
--- a/src/chartopts/toolbox.jl
+++ b/src/chartopts/toolbox.jl
@@ -1,3 +1,16 @@
+# Display titles for ECharts magicType chart-toggle buttons.
+# Add an entry here whenever a new chart type that supports magicType is introduced.
+const MAGICTYPE_TITLES = Dict(
+    "line"    => "Line",
+    "bar"     => "Bar",
+    "stack"   => "Stack",
+    "tiled"   => "Tiled",
+    "force"   => "Force",
+    "chord"   => "Chord",
+    "pie"     => "Pie",
+    "funnel"  => "Funnel",
+)
+
 """
     toolbox!(ec)
 
@@ -46,16 +59,6 @@ function toolbox!(ec::EChart; 	show::Bool = true,
 								)
 	# Assumes Toolbox already exists in EChart, which is true by composite type definition
 
-	chartlookup = Dict(	"line" => "Line",
-						"bar" => "Bar",
-						"stack" => "Stack",
-						"tiled" => "Tiled",
-						"force" => "Force",
-						"chord" => "Chord",
-						"pie" => "Pie",
-						"funnel" => "Funnel"
-						)
-
 	ec.toolbox.show = show
 	ec.toolbox.orient = orient
 
@@ -68,7 +71,7 @@ function toolbox!(ec::EChart; 	show::Bool = true,
 	dataView ? ec.toolbox.feature["dataView"] = Dict("show" => true, "title" => "Data View", "lang" => ["Data View", "Cancel", "Refresh"]) : ec.toolbox.feature["dataView"] = Dict("show" => false)
 	saveAsImage ? ec.toolbox.feature["saveAsImage"] = Dict("show" => true, "title" => "Save As PNG") : ec.toolbox.feature["saveAsImage"] = Dict("show" => false)
 	dataZoom ? ec.toolbox.feature["dataZoom"] = Dict("show" => true, "title" => Dict("zoom" => "Zoom", "back" => "Zoom Reset")) : nothing
-	chartTypes != [] ? ec.toolbox.feature["magicType"] = Dict("show" => true, "type" => chartTypes, "title" => chartlookup) : nothing
+	chartTypes != [] ? ec.toolbox.feature["magicType"] = Dict("show" => true, "type" => chartTypes, "title" => MAGICTYPE_TITLES) : nothing
 
 	return ec
 

--- a/src/chartopts/tooltip.jl
+++ b/src/chartopts/tooltip.jl
@@ -1,3 +1,11 @@
+# Chart types that use "axis" trigger (cross-hair tooltip across all series at one x position).
+# All other chart types default to "item" trigger (per-point tooltip).
+# Add an entry here whenever a new Cartesian chart type is introduced.
+const AXIS_TRIGGER_CHARTTYPES = (
+    "xy plot", "bar", "line", "area", "waterfall", "histogram",
+    "streamgraph", "box", "candlestick", "corrplot", "heatmap", "bubble",
+)
+
 """
     tooltip!(ec)
 
@@ -49,9 +57,7 @@ function tooltip!(ec::EChart; show::Bool = true,
 
     # Auto-select trigger based on chart type when not specified
     if isnothing(trigger)
-        axis_types = ("xy plot", "bar", "line", "area", "waterfall", "histogram",
-                      "streamgraph", "box", "candlestick", "corrplot", "heatmap", "bubble")
-        trigger = ec.ec_charttype in axis_types ? "axis" : "item"
+        trigger = ec.ec_charttype in AXIS_TRIGGER_CHARTTYPES ? "axis" : "item"
     end
     ec.tooltip.trigger = trigger
 


### PR DESCRIPTION
## Summary

Two separate functions embedded chart-type lookup data inside their bodies, requiring developers to edit function internals in two places whenever a new chart type is added:

- **`toolbox!`**: `chartlookup` dict (magicType display titles) → `MAGICTYPE_TITLES` module constant
- **`tooltip!`**: `axis_types` tuple (Cartesian chart types for axis trigger) → `AXIS_TRIGGER_CHARTTYPES` module constant

Each constant now has a comment directing developers to update it when adding new chart types, making the maintenance point explicit and easy to find.

## Test plan

- [ ] Call `toolbox!(ec, chartTypes = ["line", "bar"])` and confirm the magicType titles still render correctly
- [ ] Call `tooltip!(ec)` on a bar chart and confirm trigger is `"axis"`
- [ ] Call `tooltip!(ec)` on a pie chart and confirm trigger is `"item"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)