### PR TITLE
Fix loop variable shadowing parameter x in waterfall

### DIFF
--- a/src/plots/waterfall.jl
+++ b/src/plots/waterfall.jl
@@ -23,7 +23,7 @@ function waterfall(x::AbstractVector, y::AbstractVector{<:Real};
  		kwargs...)
 
     #Need to add a value for total, since user passes in data values only
-    labels = [string(x) for x in x]
+    labels = [string(v) for v in x]
     push!(labels, "total")
 
     #Calculate transparent series as base for stacking


### PR DESCRIPTION
## Summary

- `[string(x) for x in x]` used `x` as both the function parameter (the input vector) and the loop variable, shadowing the outer `x`
- This works by accident in Julia today but is confusing to read and fragile to refactor — renaming the parameter would silently change which `x` the comprehension iterates over
- Renamed the loop variable to `v`

## Test plan

- [ ] Call `waterfall(x, y)` and confirm labels are generated correctly from the `x` input vector

🤖 Generated with [Claude Code](https://claude.com/claude-code)