### PR TITLE
Simplify candlestick data formatting with a comprehension

### DIFF
--- a/src/plots/candlestick.jl
+++ b/src/plots/candlestick.jl
@@ -37,10 +37,7 @@ function candlestick(dt::AbstractVector{String},
                      kwargs...)
 
     #Put in array of array format
-    fmtdata = []
-    for (o,c,l,h) in zip(open, close, low, high)
-        push!(fmtdata, [o,c,l,h])
-    end
+    fmtdata = [[o,c,l,h] for (o,c,l,h) in zip(open, close, low, high)]
 
     ec = newplot(kwargs, ec_charttype = "candlestick")
     ec.xAxis = [Axis(_type = "category", data = dt, scale = true, boundaryGap = true)]


### PR DESCRIPTION
## Summary

- The `candlestick` function built its `[open, close, low, high]` array-of-arrays using a `push!` loop into an untyped `fmtdata = []`
- This is directly expressible as a one-line comprehension, which is clearer, avoids the intermediate untyped variable, and lets Julia infer a concrete element type

## Test plan

- [ ] Call `candlestick(dt, open, close, low, high)` and confirm the chart renders correctly with the right OHLC values per bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)