### PR TITLE
Replace typeof(v) in [...] with isa(v, Union{...}) in kwargs!

### DIFF
--- a/src/chartopts/utilities.jl
+++ b/src/chartopts/utilities.jl
@@ -47,7 +47,7 @@ arrayofarray(x::AbstractVector,y::AbstractVector,z::AbstractVector) = [[x,y,z] f
 function kwargs!(ec::EChart, kwargs::AbstractVector)
 
 	for (k, v) in kwargs
-        k == :color && typeof(v) in [String, Dict] ? setfield!(ec, k, [v]) : setfield!(ec, k, v)
+        k == :color && isa(v, Union{String, Dict}) ? setfield!(ec, k, [v]) : setfield!(ec, k, v)
     end
 
 end


### PR DESCRIPTION
## Summary

- `typeof(v) in [String, Dict]` in `kwargs!` allocates a temporary array for the membership test and only matches exact concrete types — a `SubString` would not match `String`, for example
- `isa(v, Union{String, Dict})` is the idiomatic Julia approach: no allocation, handles subtypes correctly, and reads more clearly

## Test plan

- [ ] Pass a `color` kwarg as a plain `String` and confirm it is wrapped in a vector correctly
- [ ] Pass a `color` kwarg as a `Dict` and confirm it is wrapped in a vector correctly
- [ ] Pass any other kwarg type and confirm it is set directly without wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)