### PR TITLE
Increase chart ID entropy from 32 to 64 bits

### DIFF
--- a/src/render.jl
+++ b/src/render.jl
@@ -71,7 +71,7 @@ print(x::EChartRaw) = print(x.option)
 # Internal: shared HTML template used by both EChart and EChartRaw renderers.
 function _echarts_html(option::String, width, height, renderer::String, theme)
     theme_json = JSON.json(theme)
-    chart_id = "echarts_" * string(rand(UInt32))
+    chart_id = "echarts_" * string(rand(UInt64), base = 16)
 
     # When ECHARTS_DOCS_BUILD is set, echarts.min.js is loaded as a page asset
     # by Documenter.jl — skip inlining it to avoid bloating the output.


### PR DESCRIPTION
## Summary

- `rand(UInt32)` gave ~4.3 billion possible chart IDs — enough for typical use, but collisions become plausible when hundreds of charts are rendered in a long-running notebook session or a page with many embedded charts
- Switched to `rand(UInt64)` formatted as a 16-character hex string, giving ~18.4 quintillion possibilities
- No new dependencies needed — `Random` is already imported

## Test plan

- [ ] Render multiple charts and confirm each gets a unique `echarts_<id>` div ID
- [ ] Confirm the generated HTML is otherwise unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)