### PR TITLE
Validate gauge breakpoints are sorted and within (0, 1]

### DIFF
--- a/src/plots/gauge.jl
+++ b/src/plots/gauge.jl
@@ -20,7 +20,9 @@ function gauge(x::Union{Missing, Real};
                colors::AbstractVector = ["#91c7ae", "#63869e", "#c23531"],
                kwargs...)
 
-    length(breakpoints) != length(colors) ? error("breakpoints and colors vectors need to have the same length.") : nothing
+    length(breakpoints) != length(colors) && error("breakpoints and colors must have the same length.")
+    any(b -> b <= 0 || b > 1, breakpoints) && error("all breakpoints must be in the range (0, 1].")
+    issorted(breakpoints) || error("breakpoints must be in ascending order.")
 
     ec = newplot(kwargs, ec_charttype = "gauge")
 


### PR DESCRIPTION
## Summary

- ECharts.js interprets gauge breakpoints as percentages along the arc (0–100%), so values outside `(0, 1]` or in non-ascending order produce a silently broken or invisible chart with no JS error
- The existing check only validated that `breakpoints` and `colors` had the same length
- Added two additional guards with descriptive error messages:
  - all breakpoints must be in `(0, 1]`
  - breakpoints must be in ascending order

## Test plan

- [ ] `gauge(0.5, breakpoints=[0.2, 0.8, 1.0])` still works as before
- [ ] `gauge(0.5, breakpoints=[0.2, 1.5, 1.0])` → error about range
- [ ] `gauge(0.5, breakpoints=[0.8, 0.2, 1.0])` → error about ordering
- [ ] `gauge(0.5, breakpoints=[0.0, 0.5, 1.0])` → error about range (0 not in (0,1])

🤖 Generated with [Claude Code](https://claude.com/claude-code)