### PR TITLE
Remove redundant fill Bool→Vector expansion in multi-series radar

### DIFF
--- a/src/plots/radar.jl
+++ b/src/plots/radar.jl
@@ -68,11 +68,8 @@ function radar(names::AbstractVector,
 		push!(ec.series, RadarSeries(data = [Dict{Any, Any}("value" => values[:,i])]))
 	end
 
-	# Fill area if requested
-	# This is smelly
-	fill isa Bool ? fill = [fill for i in 1:size(values)[2]] : nothing
-	cols = length(fill)
-	fill!(ec, cols, fill)
+	# Fill area if requested — fill! handles Bool→Vector expansion internally
+	fill!(ec, size(values)[2], fill)
 
 	seriesnames!(ec)
 


### PR DESCRIPTION
## Summary

- The multi-series `radar` method manually expanded a `Bool` `fill` value into a `Vector` before calling `fill!`, but `fill!` in `utilities.jl` already performs exactly this expansion internally
- The pre-conversion was dead code, and even carried a `# This is smelly` comment acknowledging the problem
- Removed the three redundant lines and call `fill!` directly with `size(values)[2]` as the series count

## Test plan

- [ ] `radar(names, values, max, fill = true)` fills all series
- [ ] `radar(names, values, max, fill = false)` fills no series
- [ ] `radar(names, values, max, fill = [true, false])` fills only the first series

🤖 Generated with [Claude Code](https://claude.com/claude-code)