### PR TITLE
Add sampling keyword to line methods

### DIFF
--- a/src/plots/line.jl
+++ b/src/plots/line.jl
@@ -14,6 +14,7 @@ line(df, x::Symbol, y::Symbol, group::Symbol)
 ## Arguments
 * `mark::Union{String, AbstractVector} = "line"` : how to display plotted points
 * `step::Union{String, Void} = nothing` : one of {"start", "end", "middle", nothing}
+* `sampling::Union{String, Nothing} = nothing` : downsampling strategy for large datasets; one of {"lttb", "average", "min", "max", "sum", nothing}
 * `legend::Bool = false` : display legend?
 * `scale::Bool = false` : show full Y-axis or truncated
 * `kwargs` : varargs to set any field of resulting `EChart` struct
@@ -25,11 +26,14 @@ Reasonable defaults set for different methods of `area`, such as displaying a le
 function line(x::AbstractVector, y::AbstractVector{<:Union{Missing, Real}};
 			mark::Union{String, AbstractVector} = "line",
 			step::Union{String, Nothing} = nothing,
+			sampling::Union{String, Nothing} = nothing,
 			legend::Bool = false,
 			scale::Bool = false,
 			kwargs...)
 
-	return xy_plot(x, y; mark = mark, step = step, legend = legend, scale = scale, kwargs...)
+	ec = xy_plot(x, y; mark = mark, step = step, legend = legend, scale = scale, kwargs...)
+	!isnothing(sampling) ? [s.sampling = sampling for s in ec.series] : nothing
+	return ec
 
 end
 
@@ -43,11 +47,14 @@ See the primary `line` method for full argument documentation.
 function line(x::AbstractVector, y::AbstractArray{<:Union{Missing, Real},2};
 			mark::Union{String, AbstractVector} = "line",
 			step::Union{String, Nothing} = nothing,
+			sampling::Union{String, Nothing} = nothing,
 			legend::Bool = true,
 			scale::Bool = false,
 			kwargs...)
 
-	return xy_plot(x, y; mark = mark, step = step, legend = legend, scale = scale, kwargs...)
+	ec = xy_plot(x, y; mark = mark, step = step, legend = legend, scale = scale, kwargs...)
+	!isnothing(sampling) ? [s.sampling = sampling for s in ec.series] : nothing
+	return ec
 
 end
 
@@ -60,12 +67,15 @@ See the primary `line` method for full argument documentation.
 function line(df, x::Symbol, y::Symbol;
 			mark::Union{String, AbstractVector} = "line",
 			step::Union{String, Nothing} = nothing,
+			sampling::Union{String, Nothing} = nothing,
 			legend::Bool = false,
 			scale::Bool = false,
 			kwargs...)
 
 	Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
-	return xy_plot(df, x, y; mark = mark, step = step, legend = legend, scale = scale, kwargs...)
+	ec = xy_plot(df, x, y; mark = mark, step = step, legend = legend, scale = scale, kwargs...)
+	!isnothing(sampling) ? [s.sampling = sampling for s in ec.series] : nothing
+	return ec
 
 end
 
@@ -79,11 +89,14 @@ See the primary `line` method for full argument documentation.
 function line(df, x::Symbol, y::Symbol, group::Symbol;
 			mark::Union{String, AbstractVector} = "line",
 			step::Union{String, Nothing} = nothing,
+			sampling::Union{String, Nothing} = nothing,
 			legend::Bool = true,
 			scale::Bool = false,
 			kwargs...)
 
 	Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
-	return xy_plot(df, x, y, group; mark = mark, step = step, legend = legend, scale = scale, kwargs...)
+	ec = xy_plot(df, x, y, group; mark = mark, step = step, legend = legend, scale = scale, kwargs...)
+	!isnothing(sampling) ? [s.sampling = sampling for s in ec.series] : nothing
+	return ec
 
 end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -163,6 +163,19 @@ y2 = 0.6 .* y
 l2s = line(x, hcat(y, y2))
 @test typeof(l2s) == EChart
 
+x = ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"]
+y = [11, 11, 15, 13, 12, 13, 10]
+lsamp = line(x, y, sampling = "lttb")
+@test typeof(lsamp) == EChart
+@test lsamp.series[1].sampling == "lttb"
+
+x = ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"]
+y = [11, 11, 15, 13, 12, 13, 10]
+y2 = 0.6 .* y
+l2samp = line(x, hcat(y, y2), sampling = "average")
+@test typeof(l2samp) == EChart
+@test all(s.sampling == "average" for s in l2samp.series)
+
 #9: pie
 x = ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"]
 y = [11, 11, 15, 13, 12, 13, 10]


### PR DESCRIPTION
## Summary

Closes #16 (partial — `sampling` for `line`; see note on `lines` below).

- Adds `sampling::Union{String, Nothing} = nothing` to all four `line` method signatures (`x/y` vector, `x/y` 2-D array, `df/x/y`, `df/x/y/group`).
- When set, the value is applied to every series in the resulting chart, enabling ECharts' built-in downsampling for large datasets.
- Valid values mirror the ECharts docs: `"lttb"`, `"average"`, `"min"`, `"max"`, `"sum"`.
- `XYSeries` already had a `sampling` field; this change just surfaces it through the public API.

## Implementation notes

`sampling` is applied post-hoc after `xy_plot` returns (same pattern used for `step` in the multi-series path), so `xy_plot` itself is unchanged and `bar`/`area` are unaffected.

## Note on the `lines` checkbox

The second checkbox in #16 ("Add `large` keyword to the `lines` method") refers to the geographic route chart type (`LinesSeries`). `LinesSeries` already has `large`/`largeThreshold` fields in `definetypes.jl`, but no `lines` plotting function exists in the package yet. That work is tracked separately.

## Test plan

- [x] `line(x, y, sampling = "lttb")` → `series[1].sampling == "lttb"`
- [x] `line(x, hcat(y, y2), sampling = "average")` → all series have `sampling == "average"`
- [x] Full test suite passes (`Pkg.test()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)