### PR TITLE
Add savefig for HTML and JSON export

### DIFF
--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -40,6 +40,7 @@ module ECharts
 	export title!, yaxis!, xaxis!, toolbox!, colorscheme!, flip!, seriesnames!, legend!, datazoom!, smooth!
 	export yline!, xline!, lineargradient, radialgradient, text!, xarea!, yarea!, xgridlines!, ygridlines!
 	export radial!, jitter!, labels!, theme!, tooltip!, aria!, shadow!
+	export savefig
 
 
 	# Primitives - in order of descending dependency within files

--- a/src/render.jl
+++ b/src/render.jl
@@ -84,3 +84,35 @@ Base.show(io::IO, ::MIME"text/html",        ec::EChart)    = write(io, _echarts_
 Base.show(io::IO, ::MIME"juliavscode/html", ec::EChart)    = write(io, _echarts_html(ec))
 Base.show(io::IO, ::MIME"text/html",        ec::EChartRaw) = write(io, _echarts_html(ec))
 Base.show(io::IO, ::MIME"juliavscode/html", ec::EChartRaw) = write(io, _echarts_html(ec))
+
+"""
+    savefig(filename::AbstractString, ec::Union{EChart, EChartRaw})
+
+Save an EChart to a file. The output format is determined by the file extension:
+
+- `.html` — self-contained HTML page with ECharts.js embedded
+- `.json` — raw ECharts option JSON (the object passed to `setOption`)
+
+# Examples
+```julia
+chart = bar(["A","B","C"], [1,2,3])
+savefig("mychart.html", chart)   # standalone HTML page
+savefig("mychart.json", chart)   # ECharts option JSON
+```
+"""
+function savefig(filename::AbstractString, ec::Union{EChart, EChartRaw})
+    ext = lowercase(splitext(filename)[2])
+    if ext == ".html"
+        open(filename, "w") do io
+            write(io, "<!DOCTYPE html>\n<html>\n<head><meta charset=\"utf-8\"><title>ECharts</title></head>\n<body>\n")
+            write(io, _echarts_html(ec))
+            write(io, "\n</body>\n</html>\n")
+        end
+    elseif ext == ".json"
+        open(filename, "w") do io
+            write(io, ec isa EChart ? JSON.json(ec) : ec.option)
+        end
+    else
+        throw(ArgumentError("Unsupported extension \"$ext\". Use \".html\" or \".json\"."))
+    end
+end


### PR DESCRIPTION
## Summary

- Adds `savefig(filename, ec)` for both `EChart` and `EChartRaw` types
- `.html` → self-contained page with `echarts.min.js` embedded (opens in any browser, no server needed)
- `.json` → raw ECharts option JSON (the object passed to `setOption`)
- Format is inferred from the file extension; throws a clear error for unsupported extensions

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)