### PR TITLE
Add parallel coordinates chart type

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -45,6 +45,7 @@ makedocs(
             "charts/heatmap.md",
             "charts/histogram.md",
             "charts/line.md",
+            "charts/parallel.md",
             "charts/pie.md",
             "charts/polar.md",
             "charts/radar.md",

--- a/docs/src/charts/parallel.md
+++ b/docs/src/charts/parallel.md
@@ -1,0 +1,12 @@
+# parallel
+
+```@docs
+parallel
+```
+
+```@example
+using ECharts
+data = [1.0 2.0 3.0; 4.0 5.0 6.0; 7.0 8.0 9.0]
+dims = ["A", "B", "C"]
+parallel(data, dims)
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -39,6 +39,7 @@ module ECharts
 	export sunburst
 	export tree
 	export treemap
+	export parallel
 
 	export title!, yaxis!, xaxis!, toolbox!, colorscheme!, flip!, seriesnames!, legend!, datazoom!, smooth!
 	export yline!, xline!, lineargradient, radialgradient, text!, xarea!, yarea!, xgridlines!, ygridlines!
@@ -100,6 +101,7 @@ module ECharts
 	include("plots/sunburst.jl")
 	include("plots/tree.jl")
 	include("plots/treemap.jl")
+	include("plots/parallel.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/definetypes.jl
+++ b/src/definetypes.jl
@@ -1631,7 +1631,7 @@ details.
     brush::Union{Brush, Nothing} = nothing
     geo::Union{Geo, Nothing} = nothing
     parallel::Union{Parallel, Nothing} = nothing
-    parallelAxis::Union{ParallelAxis, Nothing} = nothing
+    parallelAxis::Union{AbstractVector, ParallelAxis, Nothing} = nothing
     singleAxis::Union{SingleAxis, Nothing} = nothing
     timeline::Union{Timeline, Nothing} = nothing
     graphic::Union{Graphic, Nothing} = nothing

--- a/src/plots/parallel.jl
+++ b/src/plots/parallel.jl
@@ -1,0 +1,35 @@
+"""
+    parallel(data, dims)
+
+Creates an `EChart` parallel coordinates chart.
+
+## Methods
+```julia
+parallel(data::AbstractMatrix, dims::AbstractVector{String})
+```
+
+## Arguments
+* `legend::Bool = false` : display legend?
+* `kwargs` : varargs to set any field of resulting `EChart` struct
+
+## Notes
+
+Rows of `data` represent individual observations; columns represent dimensions (axes).
+`dims` provides axis labels for each column.
+"""
+function parallel(data::AbstractMatrix, dims::AbstractVector{String};
+                  legend::Bool = false,
+                  kwargs...)
+
+    ec = newplot(kwargs, ec_charttype = "parallel")
+    ec.xAxis = nothing
+    ec.yAxis = nothing
+    ec.parallel = Parallel()
+    ec.parallelAxis = [ParallelAxis(dim = i - 1, name = dims[i]) for i in eachindex(dims)]
+    ec.series = [ParallelSeries(data = [collect(data[i, :]) for i in axes(data, 1)])]
+
+    legend ? legend!(ec) : nothing
+
+    return ec
+
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -349,3 +349,9 @@ cplot_alpha = corrplot(mtcars, order = "alphabet")
 @test typeof(cplot_alpha) == EChart
 
 @test_throws ArgumentError corrplot(mtcars, order = "invalid")
+
+# parallel
+par_data = [1.0 2.0 3.0; 4.0 5.0 6.0; 7.0 8.0 9.0]
+par_dims = ["A", "B", "C"]
+result_parallel = parallel(par_data, par_dims)
+@test typeof(result_parallel) == EChart


### PR DESCRIPTION
## Summary
- Adds `parallel(data, dims)` function for multi-dimensional data visualization
- Patches `parallelAxis` field in EChart to support vector of axes
- Enables visualization of high-dimensional datasets across parallel axes

## Test plan
- [ ] `@test typeof(result) == EChart` passes
- [ ] Docs example renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)