### PR TITLE
Add effect scatter chart type

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -40,6 +40,7 @@ makedocs(
             "charts/corrplot.md",
             "charts/donut.md",
             "charts/echart_raw.md",
+            "charts/effectscatter.md",
             "charts/funnel.md",
             "charts/gauge.md",
             "charts/heatmap.md",

--- a/docs/src/charts/effectscatter.md
+++ b/docs/src/charts/effectscatter.md
@@ -1,0 +1,12 @@
+# effectscatter
+
+```@docs
+effectscatter
+```
+
+```@example
+using ECharts
+x = randn(30)
+y = randn(30)
+effectscatter(x, y)
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -40,6 +40,7 @@ module ECharts
 	export tree
 	export treemap
 	export parallel
+	export effectscatter
 
 	export title!, yaxis!, xaxis!, toolbox!, colorscheme!, flip!, seriesnames!, legend!, datazoom!, smooth!
 	export yline!, xline!, lineargradient, radialgradient, text!, xarea!, yarea!, xgridlines!, ygridlines!
@@ -102,6 +103,7 @@ module ECharts
 	include("plots/tree.jl")
 	include("plots/treemap.jl")
 	include("plots/parallel.jl")
+	include("plots/effectscatter.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/plots/effectscatter.jl
+++ b/src/plots/effectscatter.jl
@@ -1,0 +1,35 @@
+"""
+    effectscatter(x, y)
+
+Creates an `EChart` effect scatter plot — a scatter chart with a ripple animation on each
+point, useful for emphasising highlighted locations.
+
+## Methods
+```julia
+effectscatter(x::AbstractVector{<:Real}, y::AbstractVector{<:Real})
+```
+
+## Arguments
+* `legend::Bool = false` : display legend?
+* `scale::Bool = false` : show full axis range or truncated
+* `symbol_size::Int = 10` : radius of each scatter symbol in pixels
+* `kwargs` : varargs to set any field of resulting `EChart` struct
+"""
+function effectscatter(x::AbstractVector{<:Real}, y::AbstractVector{<:Real};
+                       legend::Bool = false,
+                       scale::Bool = false,
+                       symbol_size::Int = 10,
+                       kwargs...)
+
+    ec = newplot(kwargs, ec_charttype = "effectscatter")
+    ec.xAxis = [Axis(_type = "value", scale = scale)]
+    ec.yAxis = [Axis(_type = "value", scale = scale)]
+    ec.series = [EffectScatterSeries(name = "Series 1",
+                                     data = arrayofarray(x, y),
+                                     symbolSize = symbol_size)]
+
+    legend ? legend!(ec) : nothing
+
+    return ec
+
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -355,3 +355,8 @@ par_data = [1.0 2.0 3.0; 4.0 5.0 6.0; 7.0 8.0 9.0]
 par_dims = ["A", "B", "C"]
 result_parallel = parallel(par_data, par_dims)
 @test typeof(result_parallel) == EChart
+# effectscatter
+es_x = randn(20)
+es_y = randn(20)
+result_effectscatter = effectscatter(es_x, es_y)
+@test typeof(result_effectscatter) == EChart


### PR DESCRIPTION
## Summary
- Adds `effectscatter(x, y)` function for ripple-animated scatter plots
- Uses `EffectScatterSeries` for animated ripple effects on data points
- Useful for highlighting key data points with visual emphasis

## Test plan
- [ ] `@test typeof(result) == EChart` passes
- [ ] Docs example renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)