### PR TITLE
Add network graph chart type

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -43,6 +43,7 @@ makedocs(
             "charts/effectscatter.md",
             "charts/funnel.md",
             "charts/gauge.md",
+            "charts/graph.md",
             "charts/heatmap.md",
             "charts/histogram.md",
             "charts/line.md",

--- a/docs/src/charts/graph.md
+++ b/docs/src/charts/graph.md
@@ -1,0 +1,12 @@
+# graph
+
+```@docs
+graph
+```
+
+```@example
+using ECharts
+nodes = ["A", "B", "C", "D"]
+links = [["A", "B"], ["B", "C"], ["C", "D"], ["D", "A"]]
+graph(nodes, links)
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -41,6 +41,7 @@ module ECharts
 	export treemap
 	export parallel
 	export effectscatter
+	export graph
 
 	export title!, yaxis!, xaxis!, toolbox!, colorscheme!, flip!, seriesnames!, legend!, datazoom!, smooth!
 	export yline!, xline!, lineargradient, radialgradient, text!, xarea!, yarea!, xgridlines!, ygridlines!
@@ -104,6 +105,7 @@ module ECharts
 	include("plots/treemap.jl")
 	include("plots/parallel.jl")
 	include("plots/effectscatter.jl")
+	include("plots/graph.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/plots/graph.jl
+++ b/src/plots/graph.jl
@@ -1,0 +1,44 @@
+"""
+    graph(nodes, links)
+
+Creates an `EChart` force-directed network graph.
+
+## Methods
+```julia
+graph(nodes::AbstractVector{String}, links::AbstractVector)
+```
+
+## Arguments
+* `layout::String = "force"` : graph layout algorithm (`"force"`, `"circular"`, or `"none"`)
+* `roam::Bool = true` : allow panning and zooming
+* `repulsion::Int = 100` : repulsion force between nodes in force layout
+* `kwargs` : varargs to set any field of resulting `EChart` struct
+
+## Notes
+
+`links` is a vector of two-element indexable items (e.g. `["A", "B"]` or `("A", "B")`),
+where each pair represents a directed edge from source to target.
+"""
+function graph(nodes::AbstractVector{String},
+               links::AbstractVector;
+               layout::String = "force",
+               roam::Bool = true,
+               repulsion::Int = 100,
+               kwargs...)
+
+    node_data = [Dict("name" => n) for n in nodes]
+    link_data = [Dict("source" => l[1], "target" => l[2]) for l in links]
+
+    ec = newplot(kwargs, ec_charttype = "graph")
+    ec.xAxis = nothing
+    ec.yAxis = nothing
+    ec.series = [GraphSeries(layout = layout,
+                             data = node_data,
+                             links = link_data,
+                             roam = roam,
+                             label = Label(show = true),
+                             force = Dict("repulsion" => repulsion))]
+
+    return ec
+
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -360,3 +360,8 @@ es_x = randn(20)
 es_y = randn(20)
 result_effectscatter = effectscatter(es_x, es_y)
 @test typeof(result_effectscatter) == EChart
+# graph
+g_nodes = ["A", "B", "C", "D"]
+g_links = [["A", "B"], ["B", "C"], ["C", "D"], ["D", "A"]]
+result_graph = graph(g_nodes, g_links)
+@test typeof(result_graph) == EChart


### PR DESCRIPTION
## Summary
- Adds `graph(nodes, links)` function for force-directed/network visualization
- Uses `GraphSeries` for rendering nodes and edges
- Supports network topology, relationship, and dependency visualization

## Test plan
- [ ] `@test typeof(result) == EChart` passes
- [ ] Docs example renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)