### PR TITLE
Add calendar heatmap chart type

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -36,6 +36,7 @@ makedocs(
             "charts/bar.md",
             "charts/box.md",
             "charts/bubble.md",
+            "charts/calendar_heatmap.md",
             "charts/candlestick.md",
             "charts/corrplot.md",
             "charts/donut.md",

--- a/docs/src/charts/calendar_heatmap.md
+++ b/docs/src/charts/calendar_heatmap.md
@@ -1,0 +1,12 @@
+# calendar_heatmap
+
+```@docs
+calendar_heatmap
+```
+
+```@example
+using ECharts, Dates
+dates = [Date(2023, 1, 1) + Day(i) for i in 0:364]
+values = rand(365)
+calendar_heatmap(dates, values, 2023)
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -42,6 +42,7 @@ module ECharts
 	export parallel
 	export effectscatter
 	export graph
+	export calendar_heatmap
 
 	export title!, yaxis!, xaxis!, toolbox!, colorscheme!, flip!, seriesnames!, legend!, datazoom!, smooth!
 	export yline!, xline!, lineargradient, radialgradient, text!, xarea!, yarea!, xgridlines!, ygridlines!
@@ -106,6 +107,7 @@ module ECharts
 	include("plots/parallel.jl")
 	include("plots/effectscatter.jl")
 	include("plots/graph.jl")
+	include("plots/calendar_heatmap.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/plots/calendar_heatmap.jl
+++ b/src/plots/calendar_heatmap.jl
@@ -1,0 +1,47 @@
+"""
+    calendar_heatmap(dates, values, year)
+
+Creates an `EChart` calendar heatmap showing daily values laid out in a calendar grid.
+
+## Methods
+```julia
+calendar_heatmap(dates::AbstractVector{Date}, values::AbstractVector{<:Real}, year::Int)
+```
+
+## Arguments
+* `show::Bool = true` : show the visual map slider
+* `calculable::Bool = true` : allow user to slide endpoints to change data displayed
+* `kwargs` : varargs to set any field of resulting `EChart` struct
+
+## Notes
+
+Each element of `dates` is paired with the corresponding element of `values`. Only dates
+within the specified `year` are rendered.
+"""
+function calendar_heatmap(dates::AbstractVector{Dates.Date},
+                          values::AbstractVector{<:Real},
+                          year::Int;
+                          show::Bool = true,
+                          calculable::Bool = true,
+                          kwargs...)
+
+    data = [[Dates.format(d, "yyyy-mm-dd"), v] for (d, v) in zip(dates, values)]
+
+    ec = newplot(kwargs, ec_charttype = "calendar_heatmap")
+    ec.xAxis = nothing
+    ec.yAxis = nothing
+    ec.calendar = Calendar(range = string(year), cellSize = ["auto", 13])
+    ec.series = [HeatmapSeries(coordinateSystem = "calendar", data = data)]
+
+    minval, maxval = extrema(values)
+    ec.visualMap = VisualMap(show = show,
+                             min = minval,
+                             max = maxval,
+                             calculable = calculable,
+                             orient = "horizontal",
+                             left = "center",
+                             top = "top")
+
+    return ec
+
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -365,3 +365,9 @@ g_nodes = ["A", "B", "C", "D"]
 g_links = [["A", "B"], ["B", "C"], ["C", "D"], ["D", "A"]]
 result_graph = graph(g_nodes, g_links)
 @test typeof(result_graph) == EChart
+# calendar_heatmap
+using Dates
+cal_dates = [Date(2023, 1, 1) + Day(i) for i in 0:364]
+cal_values = rand(365)
+result_cal = calendar_heatmap(cal_dates, cal_values, 2023)
+@test typeof(result_cal) == EChart


### PR DESCRIPTION
## Summary
- Adds `calendar_heatmap(dates, values, year)` function for daily value heatmaps
- Uses `Calendar` component combined with `HeatmapSeries` for rendering
- Ideal for visualizing time-series data like activity, commits, or metrics by day

## Test plan
- [ ] `@test typeof(result) == EChart` passes
- [ ] Docs example renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)