### PR TITLE
Add punch card chart type

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -50,6 +50,7 @@ makedocs(
             "charts/line.md",
             "charts/parallel.md",
             "charts/pie.md",
+            "charts/punchcard.md",
             "charts/polar.md",
             "charts/radar.md",
             "charts/radialbar.md",

--- a/docs/src/charts/punchcard.md
+++ b/docs/src/charts/punchcard.md
@@ -1,0 +1,13 @@
+# punchcard
+
+```@docs
+punchcard
+```
+
+```@example
+using ECharts
+days  = repeat(["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"], 24)
+hours = repeat(string.(0:23), inner = 7)
+counts = rand(1:500, length(days))
+punchcard(days, hours, counts)
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -43,6 +43,7 @@ module ECharts
 	export effectscatter
 	export graph
 	export calendar_heatmap
+	export punchcard
 
 	export title!, yaxis!, xaxis!, toolbox!, colorscheme!, flip!, seriesnames!, legend!, datazoom!, smooth!
 	export yline!, xline!, lineargradient, radialgradient, text!, xarea!, yarea!, xgridlines!, ygridlines!
@@ -108,6 +109,7 @@ module ECharts
 	include("plots/effectscatter.jl")
 	include("plots/graph.jl")
 	include("plots/calendar_heatmap.jl")
+	include("plots/punchcard.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/plots/punchcard.jl
+++ b/src/plots/punchcard.jl
@@ -1,0 +1,46 @@
+"""
+    punchcard(x, y, sizes)
+
+Creates an `EChart` punchcard (bubble grid) chart — a scatter plot on a categorical grid
+where bubble size encodes a third variable, similar to a GitHub-style punch card.
+
+## Methods
+```julia
+punchcard(x::AbstractVector, y::AbstractVector, sizes::AbstractVector{<:Real})
+```
+
+## Arguments
+* `scale::Real = 10` : divisor applied to `sizes` to control the maximum bubble radius
+* `legend::Bool = false` : display legend?
+* `kwargs` : varargs to set any field of resulting `EChart` struct
+
+## Notes
+
+`x`, `y`, and `sizes` must be the same length. Each triplet `(x[i], y[i], sizes[i])`
+defines one bubble at the grid intersection `(x[i], y[i])` with size proportional to
+`sizes[i]`. Duplicate `(x, y)` pairs are allowed — all corresponding bubbles will be drawn.
+"""
+function punchcard(x::AbstractVector, y::AbstractVector,
+                   sizes::AbstractVector{<:Real};
+                   scale::Real = 10,
+                   legend::Bool = false,
+                   kwargs...)
+
+    unique_x = unique(x)
+    unique_y = unique(y)
+
+    data = [[xi, yi, si] for (xi, yi, si) in zip(x, y, sizes)]
+
+    ec = newplot(kwargs, ec_charttype = "punchcard")
+    ec.xAxis = [Axis(_type = "category", data = collect(string.(unique_x)))]
+    ec.yAxis = [Axis(_type = "category", data = collect(string.(unique_y)))]
+    ec.series = [XYSeries(_type = "scatter",
+                          data = data,
+                          symbolSize = JSON.JSONText(
+                              "(function(val){ return val[2] / $scale; })"))]
+
+    legend ? legend!(ec) : nothing
+
+    return ec
+
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -371,3 +371,9 @@ cal_dates = [Date(2023, 1, 1) + Day(i) for i in 0:364]
 cal_values = rand(365)
 result_cal = calendar_heatmap(cal_dates, cal_values, 2023)
 @test typeof(result_cal) == EChart
+# punchcard
+pc_x = repeat(["Mon", "Tue", "Wed", "Thu", "Fri"], 3)
+pc_y = repeat(["Morning", "Afternoon", "Evening"], inner = 5)
+pc_sizes = rand(1:100, 15)
+result_punchcard = punchcard(pc_x, pc_y, pc_sizes)
+@test typeof(result_punchcard) == EChart


### PR DESCRIPTION
## Summary
- Adds `punchcard(x, y, sizes)` function for bubble-on-categorical-grid charts
- Renders bubbles sized by value at categorical grid intersections (like GitHub punch card)
- Useful for visualizing frequency or magnitude across two categorical dimensions

## Test plan
- [ ] `@test typeof(result) == EChart` passes
- [ ] Docs example renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)