### PR TITLE
Add beeswarm chart type

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -34,6 +34,7 @@ makedocs(
         "Charts" => [
             "charts/area.md",
             "charts/bar.md",
+            "charts/beeswarm.md",
             "charts/box.md",
             "charts/bubble.md",
             "charts/calendar_heatmap.md",

--- a/docs/src/charts/beeswarm.md
+++ b/docs/src/charts/beeswarm.md
@@ -1,0 +1,12 @@
+# beeswarm
+
+```@docs
+beeswarm
+```
+
+```@example
+using ECharts
+categories = vcat(fill("Control", 30), fill("Treatment A", 30), fill("Treatment B", 30))
+values = vcat(randn(30), randn(30) .+ 1.5, randn(30) .+ 3)
+beeswarm(categories, values)
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -44,6 +44,7 @@ module ECharts
 	export graph
 	export calendar_heatmap
 	export punchcard
+	export beeswarm
 
 	export title!, yaxis!, xaxis!, toolbox!, colorscheme!, flip!, seriesnames!, legend!, datazoom!, smooth!
 	export yline!, xline!, lineargradient, radialgradient, text!, xarea!, yarea!, xgridlines!, ygridlines!
@@ -110,6 +111,7 @@ module ECharts
 	include("plots/graph.jl")
 	include("plots/calendar_heatmap.jl")
 	include("plots/punchcard.jl")
+	include("plots/beeswarm.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/plots/beeswarm.jl
+++ b/src/plots/beeswarm.jl
@@ -1,0 +1,49 @@
+"""
+    beeswarm(categories, values)
+
+Creates an `EChart` beeswarm plot — a scatter chart on a categorical axis with random
+jitter applied along the categorical dimension to reduce overplotting.
+
+## Methods
+```julia
+beeswarm(categories::AbstractVector, values::AbstractVector{<:Real})
+```
+
+## Arguments
+* `jitter_width::Real = 0.3` : half-width of the uniform jitter range (in category units)
+* `legend::Bool = false` : display legend?
+* `kwargs` : varargs to set any field of resulting `EChart` struct
+
+## Notes
+
+`categories` and `values` must be the same length (long-format data). Each unique category
+is mapped to an integer position on the x-axis, and points within a category receive a
+small random horizontal offset drawn from `Uniform(-jitter_width, jitter_width)`.
+"""
+function beeswarm(categories::AbstractVector, values::AbstractVector{<:Real};
+                  jitter_width::Real = 0.3,
+                  legend::Bool = false,
+                  kwargs...)
+
+    cat_labels = unique(categories)
+    cat_index  = Dict(c => i for (i, c) in enumerate(cat_labels))
+
+    data = [[cat_index[categories[i]] + (rand() * 2 - 1) * jitter_width, values[i]]
+            for i in eachindex(values)]
+
+    ec = newplot(kwargs, ec_charttype = "beeswarm")
+    ec.xAxis = [Axis(_type = "value",
+                     min = 0,
+                     max = length(cat_labels) + 1,
+                     axisLabel = AxisLabel(formatter = JSON.JSONText(
+                         "(function(v){ var labels=" *
+                         JSON.json(cat_labels) *
+                         "; return labels[Math.round(v)-1] || ''; })")))]
+    ec.yAxis = [Axis(_type = "value")]
+    ec.series = [XYSeries(name = "Series 1", _type = "scatter", data = data)]
+
+    legend ? legend!(ec) : nothing
+
+    return ec
+
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -377,3 +377,8 @@ pc_y = repeat(["Morning", "Afternoon", "Evening"], inner = 5)
 pc_sizes = rand(1:100, 15)
 result_punchcard = punchcard(pc_x, pc_y, pc_sizes)
 @test typeof(result_punchcard) == EChart
+# beeswarm
+bs_cats = vcat(fill("A", 20), fill("B", 20), fill("C", 20))
+bs_vals = randn(60)
+result_beeswarm = beeswarm(bs_cats, bs_vals)
+@test typeof(result_beeswarm) == EChart


### PR DESCRIPTION
## Summary
- Adds `beeswarm(categories, values)` function for jittered scatter on categorical axis
- Avoids overplotting by distributing points laterally within each category
- Useful for showing full distribution of values across categories

## Test plan
- [ ] `@test typeof(result) == EChart` passes
- [ ] Docs example renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)