### PR TITLE
Add population pyramid chart type

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -52,6 +52,7 @@ makedocs(
             "charts/parallel.md",
             "charts/pie.md",
             "charts/punchcard.md",
+            "charts/population_pyramid.md",
             "charts/polar.md",
             "charts/radar.md",
             "charts/radialbar.md",

--- a/docs/src/charts/population_pyramid.md
+++ b/docs/src/charts/population_pyramid.md
@@ -1,0 +1,13 @@
+# population_pyramid
+
+```@docs
+population_pyramid
+```
+
+```@example
+using ECharts
+ages = ["0-9", "10-19", "20-29", "30-39", "40-49", "50-59", "60-69", "70+"]
+male   = [100, 120, 130, 110, 95, 80, 60, 30]
+female = [95,  115, 125, 105, 90, 78, 62, 35]
+population_pyramid(ages, male, female)
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -45,6 +45,7 @@ module ECharts
 	export calendar_heatmap
 	export punchcard
 	export beeswarm
+	export population_pyramid
 
 	export title!, yaxis!, xaxis!, toolbox!, colorscheme!, flip!, seriesnames!, legend!, datazoom!, smooth!
 	export yline!, xline!, lineargradient, radialgradient, text!, xarea!, yarea!, xgridlines!, ygridlines!
@@ -112,6 +113,7 @@ module ECharts
 	include("plots/calendar_heatmap.jl")
 	include("plots/punchcard.jl")
 	include("plots/beeswarm.jl")
+	include("plots/population_pyramid.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/plots/population_pyramid.jl
+++ b/src/plots/population_pyramid.jl
@@ -1,0 +1,45 @@
+"""
+    population_pyramid(ages, male, female)
+
+Creates an `EChart` population pyramid with age groups on the y-axis and bars diverging
+left (male) and right (female) on the x-axis.
+
+## Methods
+```julia
+population_pyramid(ages::AbstractVector{String},
+                   male::AbstractVector{<:Real},
+                   female::AbstractVector{<:Real})
+```
+
+## Arguments
+* `legend::Bool = true` : display legend?
+* `male_name::String = "Male"` : series label for male data
+* `female_name::String = "Female"` : series label for female data
+* `kwargs` : varargs to set any field of resulting `EChart` struct
+
+## Notes
+
+Male values are plotted as negative so bars extend to the left. Pass positive values for
+both `male` and `female`; negation is handled internally.
+"""
+function population_pyramid(ages::AbstractVector{String},
+                             male::AbstractVector{<:Real},
+                             female::AbstractVector{<:Real};
+                             legend::Bool = true,
+                             male_name::String = "Male",
+                             female_name::String = "Female",
+                             kwargs...)
+
+    ec = newplot(kwargs, ec_charttype = "population_pyramid")
+    ec.xAxis = [Axis(_type = "value")]
+    ec.yAxis = [Axis(_type = "category", data = collect(ages))]
+    ec.series = [
+        XYSeries(name = male_name,   _type = "bar", data = [-m for m in male]),
+        XYSeries(name = female_name, _type = "bar", data = collect(female)),
+    ]
+
+    legend ? legend!(ec) : nothing
+
+    return ec
+
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -382,3 +382,9 @@ bs_cats = vcat(fill("A", 20), fill("B", 20), fill("C", 20))
 bs_vals = randn(60)
 result_beeswarm = beeswarm(bs_cats, bs_vals)
 @test typeof(result_beeswarm) == EChart
+# population_pyramid
+pp_ages = ["0-9", "10-19", "20-29", "30-39"]
+pp_male = [100, 120, 130, 110]
+pp_female = [95, 115, 125, 105]
+result_pyramid = population_pyramid(pp_ages, pp_male, pp_female)
+@test typeof(result_pyramid) == EChart


### PR DESCRIPTION
## Summary
- Adds `population_pyramid(ages, male, female)` function for diverging horizontal bar charts
- Renders dual horizontal bar series mirrored on a shared categorical axis
- Standard visualization for demographic age/gender distributions

## Test plan
- [ ] `@test typeof(result) == EChart` passes
- [ ] Docs example renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)