### PR TITLE
Add Gantt chart type

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -44,6 +44,7 @@ makedocs(
             "charts/echart_raw.md",
             "charts/effectscatter.md",
             "charts/funnel.md",
+            "charts/gantt.md",
             "charts/gauge.md",
             "charts/graph.md",
             "charts/heatmap.md",

--- a/docs/src/charts/gantt.md
+++ b/docs/src/charts/gantt.md
@@ -1,0 +1,13 @@
+# gantt
+
+```@docs
+gantt
+```
+
+```@example
+using ECharts, Dates
+tasks  = ["Design", "Development", "Testing", "Deployment"]
+starts = [Date(2024, 1, 1), Date(2024, 2, 1), Date(2024, 4, 1), Date(2024, 5, 1)]
+ends   = [Date(2024, 2, 1), Date(2024, 4, 1), Date(2024, 5, 1), Date(2024, 5, 15)]
+gantt(tasks, starts, ends)
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -46,6 +46,7 @@ module ECharts
 	export punchcard
 	export beeswarm
 	export population_pyramid
+	export gantt
 
 	export title!, yaxis!, xaxis!, toolbox!, colorscheme!, flip!, seriesnames!, legend!, datazoom!, smooth!
 	export yline!, xline!, lineargradient, radialgradient, text!, xarea!, yarea!, xgridlines!, ygridlines!
@@ -114,6 +115,7 @@ module ECharts
 	include("plots/punchcard.jl")
 	include("plots/beeswarm.jl")
 	include("plots/population_pyramid.jl")
+	include("plots/gantt.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/plots/gantt.jl
+++ b/src/plots/gantt.jl
@@ -1,0 +1,43 @@
+"""
+    gantt(tasks, start_dates, end_dates)
+
+Creates an `EChart` Gantt chart with a time x-axis and tasks on the y-axis.
+Each task is drawn as a horizontal bar spanning from its start date to its end date.
+
+## Methods
+```julia
+gantt(tasks::AbstractVector{String},
+      start_dates::AbstractVector{Dates.Date},
+      end_dates::AbstractVector{Dates.Date})
+```
+
+## Arguments
+* `legend::Bool = false` : display legend?
+* `kwargs` : varargs to set any field of resulting `EChart` struct
+
+## Notes
+
+Dates are converted to millisecond timestamps (Unix epoch) for ECharts' time axis.
+The bar data format is `[start_ms, end_ms]` per task row.
+"""
+function gantt(tasks::AbstractVector{String},
+               start_dates::AbstractVector{Dates.Date},
+               end_dates::AbstractVector{Dates.Date};
+               legend::Bool = false,
+               kwargs...)
+
+    # Convert dates to millisecond timestamps (ECharts time axis uses ms)
+    to_ms(d::Dates.Date) = Dates.value(Dates.DateTime(d)) - Dates.value(Dates.DateTime(Dates.Date(1970, 1, 1)))
+
+    data = [[to_ms(start_dates[i]), to_ms(end_dates[i])] for i in eachindex(tasks)]
+
+    ec = newplot(kwargs, ec_charttype = "gantt")
+    ec.xAxis = [Axis(_type = "time")]
+    ec.yAxis = [Axis(_type = "category", data = collect(tasks))]
+    ec.series = [XYSeries(name = "Tasks", _type = "bar", data = data)]
+
+    legend ? legend!(ec) : nothing
+
+    return ec
+
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -388,3 +388,10 @@ pp_male = [100, 120, 130, 110]
 pp_female = [95, 115, 125, 105]
 result_pyramid = population_pyramid(pp_ages, pp_male, pp_female)
 @test typeof(result_pyramid) == EChart
+# gantt
+using Dates
+gantt_tasks  = ["Design", "Development", "Testing", "Deployment"]
+gantt_starts = [Date(2024, 1, 1), Date(2024, 2, 1), Date(2024, 4, 1), Date(2024, 5, 1)]
+gantt_ends   = [Date(2024, 2, 1), Date(2024, 4, 1), Date(2024, 5, 1), Date(2024, 5, 15)]
+result_gantt = gantt(gantt_tasks, gantt_starts, gantt_ends)
+@test typeof(result_gantt) == EChart


### PR DESCRIPTION
## Summary
- Adds `gantt(tasks, start_dates, end_dates)` function for project timeline charts
- Uses time-based x-axis for rendering task durations as horizontal bars
- Standard project management visualization for schedules and dependencies

## Test plan
- [ ] `@test typeof(result) == EChart` passes
- [ ] Docs example renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)