### PR TITLE
Fix type bugs and usability issues in new chart types

### DIFF
--- a/src/chartopts/utilities.jl
+++ b/src/chartopts/utilities.jl
@@ -58,7 +58,7 @@ function fill!(ec::EChart, cols::Int, fill::Union{Bool, Vector})
     fill isa Bool ? fill = [fill for i in 1:cols] : nothing
 
     for i in 1:cols
-        fill[i] ? ec.series[i].areaStyle = ItemStyle() : nothing
+        fill[i] ? ec.series[i].areaStyle = AreaStyle() : nothing
     end
 
 end

--- a/src/definetypes.jl
+++ b/src/definetypes.jl
@@ -701,9 +701,9 @@ end
     _type::Union{String, Nothing} = "value"
     name::Union{String, Nothing} = nothing
     nameLocation::Union{String, Nothing} = "start"
-    nameTextStyle::Union{TextStyle, Nothing} = "#fff"
+    nameTextStyle::Union{TextStyle, Nothing} = TextStyle(color = "#fff")
     nameGap::Union{Int, Nothing} = 15
-    nameRotate::Union{Int, Nothing}
+    nameRotate::Union{Int, Nothing} = nothing
     inverse::Union{Bool, Nothing} = false
     boundaryGap::Union{AbstractVector,Bool, Nothing} = nothing
     min::Union{Int,String, Nothing} = "auto"
@@ -922,7 +922,7 @@ ECharts series configuration for radar (spider/web) charts.
     label::Union{Label, Nothing} = nothing
     itemStyle::Union{ItemStyle, Nothing} = nothing
     lineStyle::Union{LineStyle, Nothing} = nothing
-    areaStyle::Union{ItemStyle, Nothing} = nothing
+    areaStyle::Union{AreaStyle, Nothing} = nothing
     emphasis::Union{Dict, Nothing} = nothing
     data::Union{AbstractVector, Nothing}
     zlevel::Union{Int, Nothing} = nothing
@@ -1558,8 +1558,8 @@ This is the series type used internally by [`bar`](@ref), [`line`](@ref), [`scat
     step::Union{String, Nothing} = nothing
     label::Union{Label, Nothing} = nothing
     itemStyle::Union{ItemStyle, Nothing} = nothing
-    lineStyle::Union{ItemStyle, Nothing} = nothing
-    areaStyle::Union{ItemStyle, Nothing} = nothing
+    lineStyle::Union{LineStyle, Nothing} = nothing
+    areaStyle::Union{AreaStyle, Nothing} = nothing
     smooth::Union{Bool, Nothing} = false
     smoothMonotone::Union{String, Nothing} = nothing
     sampling::Union{String, Nothing} = nothing

--- a/src/plots/ridgeline.jl
+++ b/src/plots/ridgeline.jl
@@ -13,23 +13,23 @@ ridgeline(groups::AbstractVector{String}, data::AbstractVector{<:AbstractVector}
 * `npoints::Int = 200` : number of KDE evaluation points per group
 * `overlap::Real = 0.6` : fraction of the per-group y-range used as the vertical offset
                            between successive groups (0 = no overlap, 1 = full overlap)
-* `legend::Bool = false` : display legend?
+* `legend::Bool = true` : display legend?
 * `kwargs` : varargs to set any field of resulting `EChart` struct
 
 ## Notes
 
 `groups` and `data` must be the same length. `data[i]` is the vector of observations for
-`groups[i]`. Each group's KDE is rendered as a filled line series at a fixed y-offset;
-group labels are placed on the y-axis at those offsets.
+`groups[i]`. Each group's KDE is rendered as a filled line series at a fixed y-offset.
+The legend is shown by default since the y-axis displays numeric density offsets, not group names.
 """
 function ridgeline(groups::AbstractVector{String},
                    data::AbstractVector{<:AbstractVector};
                    npoints::Int = 200,
                    overlap::Real = 0.6,
-                   legend::Bool = false,
+                   legend::Bool = true,
                    kwargs...)
 
-    series_list = []
+    series_list = XYSeries[]
     offset      = 0.0
     step        = 1.0
 

--- a/src/plots/violin.jl
+++ b/src/plots/violin.jl
@@ -27,7 +27,7 @@ function violin(groups::AbstractVector, values::AbstractVector{<:Real};
                 kwargs...)
 
     group_labels = unique(groups)
-    series_list = []
+    series_list = XYSeries[]
 
     for (pos, grp) in enumerate(group_labels)
         idx = findall(==(grp), groups)
@@ -54,7 +54,13 @@ function violin(groups::AbstractVector, values::AbstractVector{<:Real};
     end
 
     ec = newplot(kwargs, ec_charttype = "violin")
-    ec.xAxis = [Axis(_type = "value")]
+    ec.xAxis = [Axis(_type = "value",
+                     min = 0,
+                     max = length(group_labels) + 1,
+                     axisLabel = AxisLabel(formatter = JSON.JSONText(
+                         "(function(v){ var labels=" *
+                         JSON.json(string.(group_labels)) *
+                         "; return labels[Math.round(v)-1] || ''; })")))]
     ec.yAxis = [Axis(_type = "value")]
     ec.series = series_list
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 KernelDensity = "5ab0869b-81aa-558d-bb23-cbf5423bbe9b"


### PR DESCRIPTION
## Summary

- **`definetypes.jl`**: Fix `XYSeries.lineStyle` and `XYSeries.areaStyle` wrongly typed as `ItemStyle` (should be `LineStyle` and `AreaStyle`); same fix for `RadarSeries.areaStyle`; fix `ParallelAxis.nameRotate` missing default value; fix `ParallelAxis.nameTextStyle` having a `String` default incompatible with its `TextStyle` type
- **`utilities.jl`**: Fix `fill!()` passing `ItemStyle()` to `areaStyle` — should be `AreaStyle()`
- **`violin.jl`**: x-axis now shows group names via JS label formatter (was showing raw integer positions 1, 2, 3); use typed `XYSeries[]` to satisfy `EChart.series` field type constraint
- **`ridgeline.jl`**: Use typed `XYSeries[]`; default `legend=true` since the y-axis shows numeric density offsets, not group names; fix docstring that falsely claimed group labels were placed on the y-axis
- **`test/Project.toml`**: Add missing `Dates` stdlib dependency (required by calendar_heatmap and gantt tests)

## Test plan

- [ ] `Pkg.test()` passes (all tests green before and after)
- [ ] Violin plots show group names on x-axis instead of numbers
- [ ] Ridgeline plots show legend by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)