### PR TITLE
Add nightingale rose chart

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -50,6 +50,7 @@ makedocs(
             "charts/heatmap.md",
             "charts/histogram.md",
             "charts/line.md",
+            "charts/nightingale.md",
             "charts/parallel.md",
             "charts/pie.md",
             "charts/punchcard.md",

--- a/docs/src/charts/nightingale.md
+++ b/docs/src/charts/nightingale.md
@@ -1,0 +1,13 @@
+# nightingale
+
+```@docs
+nightingale
+```
+
+```@example
+using ECharts
+labels = ["Respiratory diseases", "Zymotic diseases", "Wounds & injuries",
+          "Other causes", "Unknown"]
+values = [42, 32, 26, 18, 12]
+nightingale(labels, values)
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -49,6 +49,7 @@ module ECharts
 	export gantt
 	export ridgeline
 	export violin
+	export nightingale
 
 	export title!, yaxis!, xaxis!, toolbox!, colorscheme!, flip!, seriesnames!, legend!, datazoom!, smooth!
 	export yline!, xline!, lineargradient, radialgradient, text!, xarea!, yarea!, xgridlines!, ygridlines!
@@ -120,6 +121,7 @@ module ECharts
 	include("plots/gantt.jl")
 	include("plots/ridgeline.jl")
 	include("plots/violin.jl")
+	include("plots/nightingale.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/plots/nightingale.jl
+++ b/src/plots/nightingale.jl
@@ -1,0 +1,64 @@
+"""
+    nightingale(labels, values)
+
+Creates an `EChart` nightingale rose chart (also called a coxcomb or polar area chart),
+where each sector's **radius** (or **area**) encodes its value rather than just the angle.
+This makes differences in magnitude visually prominent.
+
+## Methods
+```julia
+nightingale(labels::AbstractVector, values::AbstractVector{<:Real})
+```
+
+## Arguments
+* `rose_type::String = "radius"` : encoding — `"radius"` (radius ∝ value, all sectors same angle) or `"area"` (area ∝ value)
+* `radius::AbstractVector{String} = ["20%", "75%"]` : inner and outer radius of the rose
+* `center::AbstractVector{String} = ["50%", "50%"]` : chart center position
+* `legend::Bool = true` : display legend?
+* `kwargs` : varargs to set any field of the resulting `EChart` struct
+
+## Notes
+
+`rose_type = "radius"` (default) gives a classic Nightingale diagram where the radius is proportional
+to the value. `rose_type = "area"` makes the sector *area* proportional to the value, which is
+more perceptually accurate.
+
+Labels are shown on the sectors by default using `"{b}: {c}"` format (name + value).
+
+# Examples
+```@example
+using ECharts
+labels = ["Respiratory", "Zymotic", "Other"]
+values = [42, 32, 26]
+nightingale(labels, values)
+```
+"""
+function nightingale(labels::AbstractVector, values::AbstractVector{<:Real};
+                     rose_type::String = "radius",
+                     radius::AbstractVector{String} = ["20%", "75%"],
+                     center::AbstractVector{String} = ["50%", "50%"],
+                     legend::Bool = true,
+                     kwargs...)
+
+    rose_type in ("radius", "area") ||
+        throw(ArgumentError("rose_type must be \"radius\" or \"area\", got \"$rose_type\""))
+    length(labels) == length(values) ||
+        throw(ArgumentError("labels and values must have the same length"))
+
+    data_fmt = arrayofdicts(value = collect(values), name = string.(labels))
+
+    ec = newplot(kwargs, ec_charttype = "nightingale")
+    ec.xAxis = nothing
+    ec.yAxis = nothing
+    ec.series = [PieSeries(
+        name    = "Nightingale",
+        roseType = rose_type,
+        radius  = radius,
+        center  = center,
+        label   = Label(show = true, formatter = "{b}: {c}"),
+        data    = data_fmt,
+    )]
+
+    legend ? legend!(ec) : nothing
+    return ec
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -407,3 +407,11 @@ result_violin = violin(vio_groups, vio_values)
 @test typeof(result_violin) == EChart
 result_violin_single = violin(randn(50))
 @test typeof(result_violin_single) == EChart
+# nightingale
+ng_labels = ["A", "B", "C", "D", "E"]
+ng_values = [42.0, 32.0, 26.0, 18.0, 12.0]
+result_nightingale = nightingale(ng_labels, ng_values)
+@test typeof(result_nightingale) == EChart
+result_nightingale_area = nightingale(ng_labels, ng_values, rose_type = "area")
+@test typeof(result_nightingale_area) == EChart
+@test_throws ArgumentError nightingale(ng_labels, ng_values, rose_type = "invalid")


### PR DESCRIPTION
## Summary

- Implements the Florence Nightingale rose / coxcomb chart as a new `nightingale(labels, values)` function
- Uses `PieSeries` with `roseType` to encode values as sector radius or area
- Supports `rose_type = "radius"` (default, classic Nightingale diagram) and `rose_type = "area"` (perceptually accurate)
- Legend shown by default; sector labels display name + value via `"{b}: {c}"` formatter

## Test plan

- [ ] `nightingale(labels, values)` returns `EChart`
- [ ] `nightingale(labels, values, rose_type = "area")` returns `EChart`
- [ ] Invalid `rose_type` throws `ArgumentError`
- [ ] Mismatched `labels`/`values` lengths throw `ArgumentError`
- [ ] Docs example renders correctly in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)