### PR TITLE
Add span chart (floating range bars)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -62,6 +62,7 @@ makedocs(
             "charts/ridgeline.md",
             "charts/sankey.md",
             "charts/scatter.md",
+            "charts/span_chart.md",
             "charts/streamgraph.md",
             "charts/sunburst.md",
             "charts/tree.md",

--- a/docs/src/charts/span_chart.md
+++ b/docs/src/charts/span_chart.md
@@ -1,0 +1,16 @@
+# span_chart
+
+```@docs
+span_chart
+```
+
+```@example
+using ECharts
+months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+          "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+temp_low  = [-3.0, -2.0, 3.0,  8.0, 13.0, 18.0,
+             20.0, 19.0, 15.0, 9.0,  3.0, -1.0]
+temp_high = [5.0,  7.0, 12.0, 18.0, 23.0, 28.0,
+             30.0, 29.0, 24.0, 17.0, 9.0,  5.0]
+span_chart(months, temp_low, temp_high)
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -51,6 +51,7 @@ module ECharts
 	export violin
 	export nightingale
 	export bullet
+	export span_chart
 
 	export title!, yaxis!, xaxis!, toolbox!, colorscheme!, flip!, seriesnames!, legend!, datazoom!, smooth!
 	export yline!, xline!, lineargradient, radialgradient, text!, xarea!, yarea!, xgridlines!, ygridlines!
@@ -124,6 +125,7 @@ module ECharts
 	include("plots/violin.jl")
 	include("plots/nightingale.jl")
 	include("plots/bullet.jl")
+	include("plots/span_chart.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/plots/span_chart.jl
+++ b/src/plots/span_chart.jl
@@ -1,0 +1,99 @@
+"""
+    span_chart(categories, lows, highs)
+
+Creates an `EChart` span (range) chart — a floating bar chart that shows a range from
+`lows[i]` to `highs[i]` for each category. Useful for visualising data ranges, error bounds,
+confidence intervals, or any quantity defined by a minimum and maximum.
+
+## Methods
+```julia
+span_chart(categories::AbstractVector, lows::AbstractVector{<:Real}, highs::AbstractVector{<:Real})
+span_chart(df, category_col::Symbol, low_col::Symbol, high_col::Symbol)
+```
+
+## Arguments
+* `color::String = "#5470c6"` : fill color of the span bars
+* `legend::Bool = false` : display legend?
+* `kwargs` : varargs to set any field of the resulting `EChart` struct
+
+## Notes
+
+Each bar "floats" above the axis: an invisible spacer bar extends from 0 to `lows[i]`,
+and the visible span bar extends from `lows[i]` to `highs[i]` (height = `highs[i] - lows[i]`).
+All values of `lows` must be ≤ the corresponding `highs`.
+
+# Examples
+```@example
+using ECharts
+months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun"]
+temp_low  = [-3.0, -2.0, 3.0, 8.0, 13.0, 18.0]
+temp_high = [5.0,  7.0, 12.0, 18.0, 23.0, 28.0]
+span_chart(months, temp_low, temp_high)
+```
+"""
+function span_chart(categories::AbstractVector,
+                    lows::AbstractVector{<:Real},
+                    highs::AbstractVector{<:Real};
+                    color::String = "#5470c6",
+                    legend::Bool = false,
+                    kwargs...)
+
+	length(categories) == length(lows) == length(highs) ||
+		throw(ArgumentError("categories, lows, and highs must all have the same length"))
+	all(lows .<= highs) ||
+		throw(ArgumentError("all lows must be ≤ the corresponding highs"))
+
+	spacer = XYSeries(
+		name      = "",
+		_type     = "bar",
+		stack     = "span",
+		data      = collect(Float64, lows),
+		itemStyle = ItemStyle(color = "transparent"),
+	)
+
+	spans = XYSeries(
+		name      = "Range",
+		_type     = "bar",
+		stack     = "span",
+		data      = collect(Float64, highs) .- collect(Float64, lows),
+		itemStyle = ItemStyle(color = color),
+	)
+
+	ec = newplot(kwargs, ec_charttype = "span_chart")
+	ec.xAxis = [Axis(_type = "category", data = string.(categories))]
+	ec.yAxis = [Axis(_type = "value")]
+	ec.series = [spacer, spans]
+
+	legend ? legend!(ec) : nothing
+	return ec
+
+end
+
+"""
+    span_chart(df, category_col, low_col, high_col)
+
+Creates an `EChart` span chart from a Tables.jl-compatible table.
+See the primary `span_chart` method for full argument documentation.
+
+# Examples
+```@example
+using ECharts, DataFrames
+df = DataFrame(
+    quarter      = ["Q1", "Q2", "Q3", "Q4"],
+    revenue_low  = [80.0, 95.0, 110.0, 130.0],
+    revenue_high = [120.0, 145.0, 165.0, 180.0],
+)
+span_chart(df, :quarter, :revenue_low, :revenue_high)
+```
+"""
+function span_chart(df, category_col::Symbol, low_col::Symbol, high_col::Symbol;
+                    color::String = "#5470c6",
+                    legend::Bool = false,
+                    kwargs...)
+	Tables.istable(df) ||
+		throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
+	cats  = _table_col(df, category_col)
+	lows  = Float64.(_table_col(df, low_col))
+	highs = Float64.(_table_col(df, high_col))
+	return span_chart(cats, lows, highs; color = color, legend = legend, kwargs...)
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -425,3 +425,13 @@ result_bullet = bullet(bl_labels, bl_actual, bl_target, bl_ranges)
 @test length(result_bullet.series) == 2  # actual bar + target scatter
 @test_throws ArgumentError bullet(bl_labels, bl_actual, bl_target, [100.0, 60.0, 80.0])  # not sorted
 @test_throws ArgumentError bullet(bl_labels, bl_actual, [80.0, 70.0], bl_ranges)  # wrong length target
+# span_chart
+sc_cats  = ["Jan", "Feb", "Mar", "Apr", "May"]
+sc_lows  = [2.0, 3.0, 8.0, 14.0, 18.0]
+sc_highs = [10.0, 12.0, 18.0, 22.0, 27.0]
+result_span = span_chart(sc_cats, sc_lows, sc_highs)
+@test typeof(result_span) == EChart
+@test length(result_span.series) == 2  # spacer + visible span
+@test result_span.series[1].itemStyle.color == "transparent"
+@test_throws ArgumentError span_chart(sc_cats, sc_highs, sc_lows)  # lows > highs
+@test_throws ArgumentError span_chart(sc_cats, sc_lows, [1.0, 2.0])  # wrong length


### PR DESCRIPTION
## Summary

- Implements `span_chart(categories, lows, highs)` — floating bars that visualise a range from `low` to `high` per category
- Adds a Tables.jl method `span_chart(df, category_col, low_col, high_col)` for DataFrame/table input
- Built with two stacked `XYSeries`: a transparent spacer bar (0 → low) and a visible colored bar (low → high)
- Useful for temperature ranges, confidence intervals, error bounds, project schedule windows, etc.

## Test plan

- [ ] `span_chart(cats, lows, highs)` returns `EChart` with 2 series
- [ ] First series (spacer) has `itemStyle.color == "transparent"`
- [ ] `lows > highs` throws `ArgumentError`
- [ ] Mismatched lengths throw `ArgumentError`
- [ ] Tables.jl method works with a `DataFrame`
- [ ] Docs example renders as expected (floating bars at correct heights)

🤖 Generated with [Claude Code](https://claude.com/claude-code)