### PR TITLE
Color beeswarm groups automatically by series

### DIFF
--- a/src/plots/beeswarm.jl
+++ b/src/plots/beeswarm.jl
@@ -19,6 +19,8 @@ beeswarm(categories::AbstractVector, values::AbstractVector{<:Real})
 `categories` and `values` must be the same length (long-format data). Each unique category
 is mapped to an integer position on the x-axis, and points within a category receive a
 small random horizontal offset drawn from `Uniform(-jitter_width, jitter_width)`.
+Each category is rendered as a separate series so that it automatically receives a
+distinct color from the active theme palette.
 """
 function beeswarm(categories::AbstractVector, values::AbstractVector{<:Real};
                   jitter_width::Real = 0.3,
@@ -27,9 +29,6 @@ function beeswarm(categories::AbstractVector, values::AbstractVector{<:Real};
 
     cat_labels = unique(categories)
     cat_index  = Dict(c => i for (i, c) in enumerate(cat_labels))
-
-    data = [[cat_index[categories[i]] + (rand() * 2 - 1) * jitter_width, values[i]]
-            for i in eachindex(values)]
 
     ec = newplot(kwargs, ec_charttype = "beeswarm")
     ec.xAxis = [Axis(_type = "value",
@@ -40,7 +39,15 @@ function beeswarm(categories::AbstractVector, values::AbstractVector{<:Real};
                          JSON.json(cat_labels) *
                          "; return labels[Math.round(v)-1] || ''; })")))]
     ec.yAxis = [Axis(_type = "value")]
-    ec.series = [XYSeries(name = "Series 1", _type = "scatter", data = data)]
+    ec.series = [
+        XYSeries(
+            name  = string(cat),
+            _type = "scatter",
+            data  = [[cat_index[categories[i]] + (rand() * 2 - 1) * jitter_width, values[i]]
+                     for i in eachindex(values) if categories[i] == cat]
+        )
+        for cat in cat_labels
+    ]
 
     legend ? legend!(ec) : nothing
 


### PR DESCRIPTION
## Summary

- Each unique category in `beeswarm` is now rendered as its own scatter series instead of all points in a single series
- ECharts automatically assigns a distinct palette color per group from the active theme
- Legend labels now correctly identify each group when `legend=true`

## Test plan

- [ ] Verify beeswarm with multiple groups shows distinct colors per group
- [ ] Verify `legend=true` displays correct group names
- [ ] Verify single-group beeswarm still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)