### PR TITLE
Fix parallel docs example: escape $ in string literal

### DIFF
--- a/docs/src/charts/parallel.md
+++ b/docs/src/charts/parallel.md
@@ -22,6 +22,6 @@ data = [
     240.0  23.0  49.0  7.8  41.0;   # SUV B
     320.0  17.0  55.0  6.5  62.0;   # SUV C
 ]
-dims = ["Horsepower", "MPG", "Weight (100 lbs)", "0-60 (sec)", "Price ($k)"]
+dims = ["Horsepower", "MPG", "Weight (100 lbs)", "0-60 (sec)", "Price (\$k)"]
 parallel(data, dims)
 ```


### PR DESCRIPTION
## Summary

- The `"Price ($k)"` string in the parallel chart `@example` block was interpreted as Julia string interpolation, causing `UndefVarError: 'k' not defined` at docs build time
- Escaped the dollar sign to `\$k` so it renders as a literal `$` in the axis label

## Test plan
- [ ] Docs build completes without error for `charts/parallel.md`
- [ ] Parallel chart renders in the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)