### PR TITLE
Color each observation line distinctly in parallel charts

### DIFF
--- a/src/plots/parallel.jl
+++ b/src/plots/parallel.jl
@@ -26,7 +26,7 @@ function parallel(data::AbstractMatrix, dims::AbstractVector{String};
     ec.yAxis = nothing
     ec.parallel = Parallel()
     ec.parallelAxis = [ParallelAxis(dim = i - 1, name = dims[i]) for i in eachindex(dims)]
-    ec.series = [ParallelSeries(data = [collect(data[i, :]) for i in axes(data, 1)])]
+    ec.series = [ParallelSeries(data = [collect(data[i, :])]) for i in axes(data, 1)]
 
     legend ? legend!(ec) : nothing
 


### PR DESCRIPTION
## Summary

- Split single `ParallelSeries` into one series per row so ECharts cycles through the theme color palette
- Each observation (row) now gets its own color by default, matching the behavior of other multi-series chart types like beeswarm

## Test plan

- [ ] Existing tests pass
- [ ] Visually verify parallel chart renders with distinct colors per line

🤖 Generated with [Claude Code](https://claude.com/claude-code)