### PR TITLE
Enable legend by default for parallel charts

### DIFF
--- a/src/plots/parallel.jl
+++ b/src/plots/parallel.jl
@@ -18,7 +18,7 @@ Rows of `data` represent individual observations; columns represent dimensions (
 `dims` provides axis labels for each column.
 """
 function parallel(data::AbstractMatrix, dims::AbstractVector{String};
-                  legend::Bool = false,
+                  legend::Bool = true,
                   kwargs...)
 
     ec = newplot(kwargs, ec_charttype = "parallel")
@@ -26,7 +26,7 @@ function parallel(data::AbstractMatrix, dims::AbstractVector{String};
     ec.yAxis = nothing
     ec.parallel = Parallel()
     ec.parallelAxis = [ParallelAxis(dim = i - 1, name = dims[i]) for i in eachindex(dims)]
-    ec.series = [ParallelSeries(data = [collect(data[i, :])]) for i in axes(data, 1)]
+    ec.series = [ParallelSeries(name = string(i), data = [collect(data[i, :])]) for i in axes(data, 1)]
 
     legend ? legend!(ec) : nothing
 


### PR DESCRIPTION
## Summary

- `legend` now defaults to `true` for `parallel()` (was `false`)
- Each observation series is named by row index (`"1"`, `"2"`, …) so the legend correctly maps colors to observations

## Test plan

- [ ] Existing tests pass
- [ ] Visually verify legend appears by default and matches observation colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)