### PR TITLE
Improve parallel chart: visible labels, tick marks, Tables.jl method

### DIFF
--- a/src/plots/parallel.jl
+++ b/src/plots/parallel.jl
@@ -6,16 +6,20 @@ Creates an `EChart` parallel coordinates chart.
 ## Methods
 ```julia
 parallel(data::AbstractMatrix, dims::AbstractVector{String})
+parallel(df, dims::AbstractVector{Symbol})
 ```
 
 ## Arguments
-* `legend::Bool = false` : display legend?
+* `legend::Bool = true` : display legend?
 * `kwargs` : varargs to set any field of resulting `EChart` struct
 
 ## Notes
 
 Rows of `data` represent individual observations; columns represent dimensions (axes).
 `dims` provides axis labels for each column.
+
+The Tables.jl method accepts any Tables.jl-compatible source (e.g. a DataFrame) and a
+vector of column symbols to use as dimensions.
 """
 function parallel(data::AbstractMatrix, dims::AbstractVector{String};
                   legend::Bool = true,
@@ -25,11 +29,27 @@ function parallel(data::AbstractMatrix, dims::AbstractVector{String};
     ec.xAxis = nothing
     ec.yAxis = nothing
     ec.parallel = Parallel()
-    ec.parallelAxis = [ParallelAxis(dim = i - 1, name = dims[i]) for i in eachindex(dims)]
+    ec.parallelAxis = [ParallelAxis(dim = i - 1, name = dims[i],
+                                   nameTextStyle = nothing,
+                                   axisTick = AxisTick(),
+                                   axisLabel = AxisLabel()) for i in eachindex(dims)]
     ec.series = [ParallelSeries(name = string(i), data = [collect(data[i, :])]) for i in axes(data, 1)]
 
     legend ? legend!(ec) : nothing
 
     return ec
 
+end
+
+"""
+    parallel(df, dims)
+
+Creates an `EChart` parallel coordinates chart from a Tables.jl-compatible source.
+See the primary `parallel` method for full argument documentation.
+"""
+function parallel(df, dims::AbstractVector{Symbol}; kwargs...)
+    Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
+    data = Float64.(hcat([_table_col(df, d) for d in dims]...))
+    dimnames = [string(d) for d in dims]
+    return parallel(data, dimnames; kwargs...)
 end


### PR DESCRIPTION
## Summary

- **Visible axis labels**: `nameTextStyle` was hardcoded to white (`#fff`), making dimension labels invisible on light backgrounds — now cleared so ECharts uses its theme default
- **Tick marks & labels**: `axisTick` and `axisLabel` are now explicitly enabled on each parallel axis
- **Tables.jl method**: `parallel(df, dims::AbstractVector{Symbol})` extracts the given columns as a matrix and uses their names as dimension labels

## Test plan

- [ ] Existing tests pass
- [ ] Dimension labels are visible on default theme
- [ ] Tick marks and numeric labels appear on each axis
- [ ] `parallel(df, [:col1, :col2, :col3])` works with a DataFrame

🤖 Generated with [Claude Code](https://claude.com/claude-code)