### PR TITLE
Fix indexing anti-patterns and variable shadowing

### DIFF
--- a/src/chartopts/seriesnames.jl
+++ b/src/chartopts/seriesnames.jl
@@ -38,8 +38,8 @@ function seriesnames!(ec::EChart, names::AbstractVector{String})
 
     length(ec.series) != length(names) ? error("Names not equal to number of Series") : nothing
 
-    for i in 1:length(ec.series)
-        ec.series[i].name = names[i]
+    for (s, name) in zip(ec.series, names)
+        s.name = name
     end
 
     #Modify legend attribute to use new seriesnames, if one exists

--- a/src/chartopts/utilities.jl
+++ b/src/chartopts/utilities.jl
@@ -29,7 +29,7 @@ function arrayofdicts(; kwargs...)
 
     for j in 1:lengths[1]
         temp = Dict()
-        for i in 1:length(k)
+        for i in eachindex(k)
             temp[string(k[i])] = v[i][j]
         end
         push!(datafmt, temp)
@@ -39,8 +39,8 @@ function arrayofdicts(; kwargs...)
 end
 
 #Combine arrays into array of arrays by each value
-arrayofarray(x::AbstractVector,y::AbstractVector) = [[x,y] for (x,y) in zip(x,y)]
-arrayofarray(x::AbstractVector,y::AbstractVector,z::AbstractVector) = [[x,y,z] for (x,y,z) in zip(x,y,z)]
+arrayofarray(x::AbstractVector,y::AbstractVector) = [[xi,yi] for (xi,yi) in zip(x,y)]
+arrayofarray(x::AbstractVector,y::AbstractVector,z::AbstractVector) = [[xi,yi,zi] for (xi,yi,zi) in zip(x,y,z)]
 
 #Common kwargs code for all plots
 #For convenience, let color be specified as a string, even though it's always an array in echarts.js

--- a/src/plots/box.jl
+++ b/src/plots/box.jl
@@ -44,16 +44,16 @@ function box(data::AbstractVector{<:AbstractVector{<:Union{Missing, Real}}};
 
     if outliers
         #Format outliers to ECharts nested array format
-        outliers = []
+        outlier_data = []
         for (i, s_) in enumerate(dataprep)
             if length(s_.outliers) > 0
                 for outlier in s_.outliers
-                    push!(outliers, [names[i], outlier])
+                    push!(outlier_data, [names[i], outlier])
                 end
             end
         end
         #hack to call this BoxPlotSeries, since the data fields are the same
-        push!(ec.series, BoxPlotSeries(name = "outliers", _type = "scatter", data = outliers))
+        push!(ec.series, BoxPlotSeries(name = "outliers", _type = "scatter", data = outlier_data))
     end
 
     #Add legend if requested

--- a/src/plots/bubble.jl
+++ b/src/plots/bubble.jl
@@ -51,7 +51,9 @@ function bubble(x::AbstractVector{<:Union{Missing, Real}},
 
 		normalized = maximum(sqrt.(size))
 
-		[x.symbolSize =  JSON.JSONText("""function (data) {return $bubblesize * Math.sqrt(data[2]) / ($normalized);}""") for x in ec.series]
+		for s in ec.series
+			s.symbolSize = JSON.JSONText("""function (data) {return $bubblesize * Math.sqrt(data[2]) / ($normalized);}""")
+		end
 
 		shadow!(ec)
 
@@ -132,11 +134,11 @@ function bubble(df, x::Symbol, y::Symbol, size::Symbol, group::Symbol;
 			seriesnames!(ec, [string(groups[i][1]) for i in 1:numgroups])
 
 			#Add legend if desired
-			legend == true ? legend!(ec) : nothing
+			legend ? legend!(ec) : nothing
 
 			#Enable optimization for lots of data
-			[x.large = large for x in ec.series]
-			[x.largeThreshold = largeThreshold for x in ec.series]
+			for s in ec.series; s.large = large; end
+			for s in ec.series; s.largeThreshold = largeThreshold; end
 
 			shadow!(ec)
 

--- a/src/plots/heatmap.jl
+++ b/src/plots/heatmap.jl
@@ -28,8 +28,8 @@ function heatmap(h::StatsBase.Histogram;
     xedges = collect(h.edges[1])
     yedges = collect(h.edges[2])
 
-    h.closed == :left ? left = "[" : left = "("
-    left == "[" ? right = ")" : right = "]"
+    left  = h.closed == :left ? "[" : "("
+    right = left == "[" ? ")" : "]"
 
     xlabels = []
     for i in 1:length(xedges)-1

--- a/src/plots/histogram.jl
+++ b/src/plots/histogram.jl
@@ -25,8 +25,8 @@ function histogram(h::StatsBase.Histogram;
     if length(h.edges) == 1
         #Create labels for bins
         edges = collect(h.edges[1])
-        h.closed == :left ? left = "[" : left = "("
-        left == "[" ? right = ")" : right = "]"
+        left  = h.closed == :left ? "[" : "("
+        right = left == "[" ? ")" : "]"
         labels = []
         for i in 1:length(edges)-1
             push!(labels, string(left, edges[i], " - ", edges[i + 1], right))

--- a/src/plots/waterfall.jl
+++ b/src/plots/waterfall.jl
@@ -37,7 +37,7 @@ function waterfall(x::AbstractVector, y::AbstractVector{<:Real};
 
     ec = bar(labels, hcat(bottom, top), stack = true, legend = legend, scale = scale, kwargs...)
     #Make bottom series transparent
-    ec.series[1].itemStyle = trans = ItemStyle(borderColor = "transparent", color = "transparent")
+    ec.series[1].itemStyle = ItemStyle(borderColor = "transparent", color = "transparent")
 
     return ec
 end

--- a/src/plots/xy_plot.jl
+++ b/src/plots/xy_plot.jl
@@ -61,7 +61,7 @@ function xy_plot(x::AbstractVector, y::AbstractArray;
 			kwargs...)
 
 	# Allow for convenience of using single string to represent same mark for all series values
-	typeof(mark) <: AbstractVector ? nothing : mark = [mark for i in 1:length(x)]
+	mark = mark isa AbstractVector ? mark : fill(mark, length(x))
 
 	#Warn if x contains missing values — they render as literal "missing" category labels
 	if eltype(x) >: Missing
@@ -89,9 +89,9 @@ function xy_plot(x::AbstractVector, y::AbstractArray;
 	#stack: this logic feels janky, but seems to work
 	if !isnothing(stack)
 		if stack == true
-			[x.stack = 1 for x in ec.series]
+			for s in ec.series; s.stack = 1; end
 		elseif typeof(stack) <: AbstractVector
-			[x.stack = stack[i] for (i,x) in enumerate(ec.series)]
+			for (i, s) in enumerate(ec.series); s.stack = stack[i]; end
 		else
 			nothing
 		end


### PR DESCRIPTION
## Summary

- Replace `1:length(x)` index loops with `eachindex` or `zip`-based iteration in `seriesnames.jl` and `utilities.jl`
- Fix variable shadowing: `outlier_data` instead of reusing `outliers` param in `box.jl`; fix `arrayofarray` destructuring variable names in `utilities.jl`
- Remove redundant intermediate assignment `trans =` in `waterfall.jl`
- Restructure ternary assignments to cleaner lvalue form (`left = cond ? a : b`) in `heatmap.jl`, `histogram.jl`, `xy_plot.jl`
- Replace side-effect list comprehensions with explicit `for` loops in `bubble.jl` and `xy_plot.jl`

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)