### PR TITLE
Add polarbar (radial column chart)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -59,6 +59,7 @@ makedocs(
             "charts/punchcard.md",
             "charts/population_pyramid.md",
             "charts/polar.md",
+            "charts/polarbar.md",
             "charts/radar.md",
             "charts/radialbar.md",
             "charts/ridgeline.md",

--- a/docs/src/charts/polarbar.md
+++ b/docs/src/charts/polarbar.md
@@ -1,0 +1,24 @@
+# polarbar
+
+```@docs
+polarbar
+```
+
+```@example
+using ECharts
+days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+sales = [120, 200, 150, 80, 70, 110, 130]
+polarbar(days, sales)
+```
+
+With multiple series (stacked):
+
+```@example stacked
+using ECharts
+days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+sales_a = [120, 200, 150, 80, 70, 110, 130]
+sales_b = [80, 120, 100, 60, 50, 90, 80]
+ec = polarbar(days, hcat(sales_a, sales_b), stack = true, legend = true)
+title!(ec, text = "Weekly Sales by Channel")
+ec
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -30,7 +30,7 @@ module ECharts
 	export AxisLine, AxisTick, AxisLabel, SplitLine, SplitArea, MarkLine, MarkArea, MarkPoint
 	export Theme, VisualMap
 
-	export xy_plot, bar, radialbar, line, scatter, area, waterfall
+	export xy_plot, bar, radialbar, polarbar, line, scatter, area, waterfall
 	export box, candlestick, sankey
 	export radar, funnel
 	export pie, donut, gauge, polar
@@ -94,6 +94,7 @@ module ECharts
 	include("plots/xy_plot.jl")
 	include("plots/bar.jl")
 	include("plots/radialbar.jl")
+	include("plots/polarbar.jl")
 	include("plots/line.jl")
 	include("plots/scatter.jl")
 	include("plots/area.jl")

--- a/src/plots/polarbar.jl
+++ b/src/plots/polarbar.jl
@@ -1,0 +1,140 @@
+"""
+    polarbar(categories, values)
+
+Creates an `EChart` polar bar chart (also called a radial column chart), where bars radiate
+outward from the centre of a circle. Categories are placed evenly around the angle axis and
+bar lengths represent the corresponding values on the radius axis.
+
+## Methods
+```julia
+polarbar(categories::AbstractVector, values::AbstractVector{<:Union{Missing, Real}})
+polarbar(categories::AbstractVector, values::AbstractArray{<:Union{Missing, Real},2})
+polarbar(df, category::Symbol, value::Symbol)
+polarbar(df, category::Symbol, value::Symbol, group::Symbol)
+```
+
+## Arguments
+* `stack::Union{Bool, Nothing} = nothing` : stack series? Pass `true` to stack all series
+* `legend::Bool` : display legend? Defaults to `true` for multi-series inputs
+* `kwargs` : varargs to set any field of resulting `EChart` struct
+
+## Notes
+
+Unlike [`radialbar`](@ref) (which converts a Cartesian bar chart to a radial layout),
+`polarbar` is built directly on ECharts' polar coordinate system with a category angle axis
+and a value radius axis, giving true circular column bars.
+
+# Examples
+```@example
+using ECharts
+days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+sales = [120, 200, 150, 80, 70, 110, 130]
+polarbar(days, sales)
+```
+"""
+function polarbar(categories::AbstractVector,
+                  values::AbstractVector{<:Union{Missing, Real}};
+                  stack::Union{Bool, Nothing} = nothing,
+                  legend::Bool = false,
+                  kwargs...)
+
+    ec = newplot(kwargs, ec_charttype = "polarbar")
+    ec.xAxis = nothing
+    ec.yAxis = nothing
+    ec.polar = [Polar()]
+    ec.angleAxis = AngleAxis(_type = "category", data = string.(categories), z = 10)
+    ec.radiusAxis = RadiusAxis(min = 0)
+
+    stack_val = stack === true ? "polarbar_stack" : nothing
+    ec.series = [XYSeries(name = "Series 1",
+                          _type = "bar",
+                          coordinateSystem = "polar",
+                          stack = stack_val,
+                          data = collect(values))]
+
+    legend ? legend!(ec) : nothing
+    return ec
+end
+
+"""
+    polarbar(categories, values)
+
+Creates an `EChart` polar bar chart from a 2-D array `values`, where each column is a
+separate series. Legend is displayed by default when multiple series are present.
+See the primary `polarbar` method for full argument documentation.
+"""
+function polarbar(categories::AbstractVector,
+                  values::AbstractArray{<:Union{Missing, Real},2};
+                  stack::Union{Bool, Nothing} = nothing,
+                  legend::Bool = true,
+                  kwargs...)
+
+    n_series = size(values, 2)
+    stack_val = stack === true ? "polarbar_stack" : nothing
+
+    ec = polarbar(categories, values[:, 1]; stack = stack, legend = false, kwargs...)
+
+    for i in 2:n_series
+        push!(ec.series,
+              XYSeries(_type = "bar",
+                       coordinateSystem = "polar",
+                       stack = stack_val,
+                       data = collect(values[:, i])))
+    end
+
+    seriesnames!(ec)
+    legend ? legend!(ec) : nothing
+    return ec
+end
+
+"""
+    polarbar(df, category, value)
+
+Creates an `EChart` polar bar chart from a single column `value` in table `df` against
+column `category`.
+See the primary `polarbar` method for full argument documentation.
+"""
+function polarbar(df, category::Symbol, value::Symbol;
+                  stack::Union{Bool, Nothing} = nothing,
+                  legend::Bool = false,
+                  kwargs...)
+    Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
+    polarbar(_table_col(df, category), _table_col(df, value);
+             stack = stack, legend = legend, kwargs...)
+end
+
+"""
+    polarbar(df, category, value, group)
+
+Creates an `EChart` polar bar chart from table `df`, grouping series by the `group` column.
+Legend is displayed by default when a group is provided.
+See the primary `polarbar` method for full argument documentation.
+"""
+function polarbar(df, category::Symbol, value::Symbol, group::Symbol;
+                  stack::Union{Bool, Nothing} = nothing,
+                  legend::Bool = true,
+                  kwargs...)
+    Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
+
+    xcol = _table_col(df, category)
+    ycol = _table_col(df, value)
+    groups = _table_groupby(df, group)
+    n_groups = length(groups)
+
+    _, idx1 = groups[1]
+    ec = polarbar(xcol[idx1], ycol[idx1]; stack = stack, legend = false, kwargs...)
+
+    for i in 2:n_groups
+        _, idxi = groups[i]
+        stack_val = stack === true ? "polarbar_stack" : nothing
+        push!(ec.series,
+              XYSeries(_type = "bar",
+                       coordinateSystem = "polar",
+                       stack = stack_val,
+                       data = collect(ycol[idxi])))
+    end
+
+    seriesnames!(ec, [string(groups[i][1]) for i in 1:n_groups])
+    legend ? legend!(ec) : nothing
+    return ec
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -453,3 +453,31 @@ ad_weights = [5.0, 3.0, 8.0, 2.0]
 result_arc_w = arcdiagram(ad_nodes, ad_links, ad_weights)
 @test typeof(result_arc_w) == EChart
 @test_throws ArgumentError arcdiagram(ad_nodes, ad_links, [1.0, 2.0])  # wrong length
+
+# polarbar
+pb_cats = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+pb_vals = [120.0, 200.0, 150.0, 80.0, 70.0, 110.0, 130.0]
+result_polarbar = polarbar(pb_cats, pb_vals)
+@test typeof(result_polarbar) == EChart
+@test result_polarbar.angleAxis._type == "category"
+@test result_polarbar.radiusAxis !== nothing
+
+result_polarbar_legend = polarbar(pb_cats, pb_vals, legend = true)
+@test typeof(result_polarbar_legend) == EChart
+
+pb_vals2 = hcat(pb_vals, 0.8 .* pb_vals)
+result_polarbar_multi = polarbar(pb_cats, pb_vals2)
+@test typeof(result_polarbar_multi) == EChart
+@test length(result_polarbar_multi.series) == 2
+
+result_polarbar_stack = polarbar(pb_cats, pb_vals2, stack = true)
+@test typeof(result_polarbar_stack) == EChart
+@test result_polarbar_stack.series[1].stack == "polarbar_stack"
+
+pb_df = DataFrame(day = pb_cats, sales = pb_vals)
+@test typeof(polarbar(pb_df, :day, :sales)) == EChart
+
+pb_df2 = DataFrame(day = vcat(pb_cats, pb_cats),
+                   sales = vcat(pb_vals, 0.8 .* pb_vals),
+                   group = vcat(fill("A", 7), fill("B", 7)))
+@test typeof(polarbar(pb_df2, :day, :sales, :group)) == EChart


### PR DESCRIPTION
## Summary

- Adds `polarbar(categories, values)` — a bar chart built directly on ECharts' polar coordinate system, with categories on the angle axis and values on the radius axis
- Distinct from the existing `radialbar` (Cartesian→polar transform) and `nightingale` (pie-based rose chart)
- Supports single-series vectors, 2-D arrays (multi-series), and Tables.jl DataFrames with optional group column
- Optional `stack=true` parameter stacks multiple series
- Includes docstring, doc page (`docs/src/charts/polarbar.md`), and tests

## Test plan

- [x] `polarbar(categories, values)` returns `EChart`
- [x] Angle axis type is `"category"` and radius axis is set
- [x] Multi-series 2-D array produces correct series count
- [x] `stack=true` sets the stack key on each series
- [x] DataFrame single-column and grouped DataFrame both work
- [x] Full test suite passes (`Pkg.test()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)