### PR TITLE
Add bump chart (ranking over time)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -36,6 +36,7 @@ makedocs(
             "charts/area.md",
             "charts/bar.md",
             "charts/beeswarm.md",
+            "charts/bump.md",
             "charts/box.md",
             "charts/bubble.md",
             "charts/bullet.md",

--- a/docs/src/charts/bump.md
+++ b/docs/src/charts/bump.md
@@ -1,0 +1,31 @@
+# bump
+
+```@docs
+bump
+```
+
+```@example
+using ECharts
+periods = ["2019", "2020", "2021", "2022", "2023"]
+values = [82.0 75.0 60.0;
+          74.0 88.0 65.0;
+          68.0 95.0 72.0;
+          91.0 70.0 80.0;
+          85.0 78.0 92.0]
+bump(periods, values, names = ["Alpha", "Beta", "Gamma"])
+```
+
+From a DataFrame:
+
+```@example df
+using ECharts, DataFrames
+df = DataFrame(
+    year  = repeat(2019:2023, inner = 3),
+    brand = repeat(["Alpha", "Beta", "Gamma"], outer = 5),
+    sales = [82.0, 75.0, 60.0, 74.0, 88.0, 65.0,
+             68.0, 95.0, 72.0, 91.0, 70.0, 80.0, 85.0, 78.0, 92.0],
+)
+ec = bump(df, :year, :sales, :brand)
+title!(ec, text = "Brand Rankings Over Time")
+ec
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -31,6 +31,7 @@ module ECharts
 	export Theme, VisualMap
 
 	export xy_plot, bar, radialbar, polarbar, line, scatter, area, waterfall
+	export bump
 	export box, candlestick, sankey
 	export radar, funnel
 	export pie, donut, gauge, polar
@@ -133,6 +134,7 @@ module ECharts
 	include("plots/span_chart.jl")
 	include("plots/chord.jl")
 	include("plots/single_axis.jl")
+	include("plots/bump.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/plots/bump.jl
+++ b/src/plots/bump.jl
@@ -1,0 +1,104 @@
+"""
+    bump(periods, values)
+
+Creates an `EChart` bump chart showing how rankings change across time periods or
+ordered categories. Each series is ranked independently at every period (rank 1 = highest
+value) and drawn as a line. The Y-axis is inverted so that rank 1 appears at the top.
+
+## Methods
+```julia
+bump(periods::AbstractVector, values::AbstractArray{<:Union{Missing, Real},2})
+bump(df, period::Symbol, value::Symbol, group::Symbol)
+```
+
+## Arguments
+* `names::Union{AbstractVector, Nothing} = nothing` : series labels (used when passing a
+  raw matrix; auto-generated when `nothing`)
+* `legend::Bool = true` : display legend?
+* `kwargs` : varargs to set any field of the resulting `EChart` struct
+
+## Notes
+
+Rankings are computed from the supplied `values` matrix — each row (period) is ranked
+independently, with rank 1 assigned to the largest value. Ties are broken by their
+position in the column order (leftmost gets the better rank).
+
+To supply pre-computed ranks, pass the rank matrix directly together with
+`yAxis` adjustment: the function always inverts the Y-axis and sets the minimum rank to 1.
+
+# Examples
+```@example
+using ECharts
+periods = ["2019", "2020", "2021", "2022", "2023"]
+values = [
+    82  74  68  91  85;   # Series A
+    75  88  95  70  78;   # Series B
+    60  65  72  80  92;   # Series C
+]'  # transpose so rows = periods
+bump(periods, values, names = ["A", "B", "C"])
+```
+"""
+function bump(periods::AbstractVector,
+              values::AbstractArray{<:Union{Missing, Real},2};
+              names::Union{AbstractVector, Nothing} = nothing,
+              legend::Bool = true,
+              kwargs...)
+
+    n_periods, n_series = size(values)
+    length(periods) == n_periods ||
+        throw(ArgumentError("length of periods ($(length(periods))) must equal number of rows in values ($n_periods)"))
+
+    # Compute ranks: rank 1 = highest value, per period (row)
+    ranks = zeros(Int, n_periods, n_series)
+    for i in 1:n_periods
+        row = [ismissing(values[i, j]) ? -Inf : Float64(values[i, j]) for j in 1:n_series]
+        ord = sortperm(row, rev = true)
+        for (rank, col_idx) in enumerate(ord)
+            ranks[i, col_idx] = rank
+        end
+    end
+
+    ec = line(string.(periods), ranks; legend = legend, kwargs...)
+
+    # Invert Y-axis: rank 1 at top, max rank at bottom; integer steps
+    ec.yAxis[1].inverse = true
+    ec.yAxis[1].min = 1
+    ec.yAxis[1].interval = 1
+
+    if names !== nothing
+        length(names) == n_series ||
+            throw(ArgumentError("length of names ($(length(names))) must equal number of series ($n_series)"))
+        seriesnames!(ec, string.(names))
+    end
+
+    return ec
+end
+
+"""
+    bump(df, period, value, group)
+
+Creates an `EChart` bump chart from a Tables.jl-compatible table. The `group` column
+identifies individual series; `value` is the magnitude ranked at each `period`.
+Legend is displayed by default.
+See the primary `bump` method for full argument documentation.
+
+# Examples
+```@example df
+using ECharts, DataFrames
+df = DataFrame(
+    year  = repeat(2019:2023, inner = 3),
+    brand = repeat(["Alpha", "Beta", "Gamma"], outer = 5),
+    sales = [82, 75, 60, 74, 88, 65, 68, 95, 72, 91, 70, 80, 85, 78, 92],
+)
+bump(df, :year, :sales, :brand)
+```
+"""
+function bump(df, period::Symbol, value::Symbol, group::Symbol;
+              legend::Bool = true,
+              kwargs...)
+    Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
+
+    periods, vals, group_names = _table_unstack(df, period, group, value)
+    vals_float = map(x -> ismissing(x) ? missing : Float64(x), vals)
+    bump(periods, vals_float; names = group_names, legend = legend, kwargs...)
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -481,3 +481,31 @@ pb_df2 = DataFrame(day = vcat(pb_cats, pb_cats),
                    sales = vcat(pb_vals, 0.8 .* pb_vals),
                    group = vcat(fill("A", 7), fill("B", 7)))
 @test typeof(polarbar(pb_df2, :day, :sales, :group)) == EChart
+
+# bump
+bump_periods = ["2019", "2020", "2021", "2022", "2023"]
+bump_vals = [82.0 75.0 60.0;
+             74.0 88.0 65.0;
+             68.0 95.0 72.0;
+             91.0 70.0 80.0;
+             85.0 78.0 92.0]
+result_bump = bump(bump_periods, bump_vals)
+@test typeof(result_bump) == EChart
+@test result_bump.yAxis[1].inverse == true
+@test result_bump.yAxis[1].min == 1
+@test length(result_bump.series) == 3
+
+result_bump_named = bump(bump_periods, bump_vals, names = ["A", "B", "C"])
+@test typeof(result_bump_named) == EChart
+@test result_bump_named.series[1].name == "A"
+
+@test_throws ArgumentError bump(bump_periods, bump_vals, names = ["A", "B"])  # wrong length
+@test_throws ArgumentError bump(["2019", "2020"], bump_vals)  # mismatched periods
+
+bump_df = DataFrame(
+    year  = repeat(2019:2023, inner = 3),
+    brand = repeat(["Alpha", "Beta", "Gamma"], outer = 5),
+    sales = [82.0, 75.0, 60.0, 74.0, 88.0, 65.0, 68.0, 95.0, 72.0, 91.0, 70.0, 80.0, 85.0, 78.0, 92.0],
+)
+result_bump_df = bump(bump_df, :year, :sales, :brand)
+@test typeof(result_bump_df) == EChart


### PR DESCRIPTION
## Summary

- Adds `bump(periods, values)` — a bump chart that converts values to per-period rankings and displays them on an inverted Y-axis so rank 1 is at the top
- Supports named series via the `names` keyword, Tables.jl DataFrames with a `group` column, and all existing `line!` modifier functions
- Includes docstring, doc page (`docs/src/charts/bump.md`), and tests covering matrix input, named series, argument errors, and DataFrame input

## Test plan

- [x] `bump(periods, matrix)` returns `EChart` with inverted Y-axis (`inverse == true`, `min == 1`)
- [x] Correct number of series created from matrix columns
- [x] Named series via `names` keyword sets series names correctly
- [x] `ArgumentError` thrown for mismatched `names` length and mismatched `periods` length
- [x] DataFrame grouped input (`bump(df, :period, :value, :group)`) works correctly
- [x] Full test suite passes (`Pkg.test()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)