### PR TITLE
Add lollipop chart

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -54,6 +54,7 @@ makedocs(
             "charts/heatmap.md",
             "charts/histogram.md",
             "charts/line.md",
+            "charts/lollipop.md",
             "charts/nightingale.md",
             "charts/parallel.md",
             "charts/pie.md",

--- a/docs/src/charts/lollipop.md
+++ b/docs/src/charts/lollipop.md
@@ -1,0 +1,24 @@
+# lollipop
+
+```@docs
+lollipop
+```
+
+```@example
+using ECharts
+categories = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+values = [120, 200, 150, 80, 70, 110, 130]
+lollipop(categories, values)
+```
+
+With multiple series and a title:
+
+```@example multi
+using ECharts
+categories = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+online  = [120, 200, 150, 80, 70, 110, 130]
+instore = [80,  120, 100, 60, 50, 90,  80]
+ec = lollipop(categories, hcat(online, instore), legend = true)
+title!(ec, text = "Weekly Sales by Channel")
+ec
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -30,7 +30,7 @@ module ECharts
 	export AxisLine, AxisTick, AxisLabel, SplitLine, SplitArea, MarkLine, MarkArea, MarkPoint
 	export Theme, VisualMap
 
-	export xy_plot, bar, radialbar, polarbar, line, scatter, area, waterfall
+	export xy_plot, bar, radialbar, polarbar, line, scatter, area, waterfall, lollipop
 	export bump
 	export box, candlestick, sankey
 	export radar, funnel
@@ -135,6 +135,7 @@ module ECharts
 	include("plots/chord.jl")
 	include("plots/single_axis.jl")
 	include("plots/bump.jl")
+	include("plots/lollipop.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/plots/lollipop.jl
+++ b/src/plots/lollipop.jl
@@ -1,0 +1,149 @@
+"""
+    lollipop(x, y)
+
+Creates an `EChart` lollipop chart — a variant of a bar chart where each value is shown
+as a dot (circle) connected to the baseline by a thin line, rather than a filled bar.
+Lollipop charts reduce visual clutter when comparing many categories.
+
+## Methods
+```julia
+lollipop(x::AbstractVector, y::AbstractVector{<:Union{Missing, Real}})
+lollipop(x::AbstractVector, y::AbstractArray{<:Union{Missing, Real},2})
+lollipop(df, x::Symbol, y::Symbol)
+lollipop(df, x::Symbol, y::Symbol, group::Symbol)
+```
+
+## Arguments
+* `dot_size::Int = 10` : diameter of the dot at the tip of each lollipop (pixels)
+* `stem_width::Int = 2` : pixel width of the stem line
+* `legend::Bool` : display legend? Defaults to `true` for multi-series inputs
+* `kwargs` : varargs to set any field of the resulting `EChart` struct
+
+## Notes
+
+Each lollipop is rendered as a scatter series (the dot) combined with a zero-width bar
+series (the stem). The stem color automatically matches the dot color via the ECharts
+color palette.
+
+# Examples
+```@example
+using ECharts
+categories = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+values = [120, 200, 150, 80, 70, 110, 130]
+lollipop(categories, values)
+```
+"""
+function lollipop(x::AbstractVector,
+                  y::AbstractVector{<:Union{Missing, Real}};
+                  dot_size::Int = 10,
+                  stem_width::Int = 2,
+                  legend::Bool = false,
+                  kwargs...)
+
+    ydata = collect(y)
+    ec = newplot(kwargs, ec_charttype = "lollipop")
+    ec.xAxis = [Axis(_type = "category", data = string.(x))]
+    ec.yAxis = [Axis(_type = "value")]
+
+    stem = XYSeries(
+        name      = "Series 1",
+        _type     = "bar",
+        barWidth  = stem_width,
+        data      = ydata,
+        itemStyle = ItemStyle(color = "inherit"),
+    )
+    dot = XYSeries(
+        name       = "Series 1",
+        _type      = "scatter",
+        symbolSize = dot_size,
+        data       = ydata,
+    )
+    ec.series = [stem, dot]
+
+    legend ? legend!(ec) : nothing
+    return ec
+end
+
+"""
+    lollipop(x, y)
+
+Creates an `EChart` lollipop chart from a 2-D array `y`, where each column is a
+separate series. Legend is displayed by default when multiple series are present.
+See the primary `lollipop` method for full argument documentation.
+"""
+function lollipop(x::AbstractVector,
+                  y::AbstractArray{<:Union{Missing, Real},2};
+                  dot_size::Int = 10,
+                  stem_width::Int = 2,
+                  legend::Bool = true,
+                  kwargs...)
+
+    n_series = size(y, 2)
+    ec = lollipop(x, y[:, 1]; dot_size = dot_size, stem_width = stem_width,
+                  legend = false, kwargs...)
+
+    for i in 2:n_series
+        ydata = collect(y[:, i])
+        push!(ec.series,
+              XYSeries(_type = "bar", barWidth = stem_width,
+                       data = ydata, itemStyle = ItemStyle(color = "inherit")))
+        push!(ec.series,
+              XYSeries(_type = "scatter", symbolSize = dot_size, data = ydata))
+    end
+
+    # Name only the scatter series (every second series is the visible dot)
+    names = ["Series $i" for i in 1:n_series]
+    for (i, s) in enumerate(ec.series)
+        s._type == "scatter" ? s.name = names[ceil(Int, i / 2)] : s.name = ""
+    end
+
+    legend ? legend!(ec) : nothing
+    return ec
+end
+
+"""
+    lollipop(df, x, y)
+
+Creates an `EChart` lollipop chart from a single column `y` in table `df` against column `x`.
+See the primary `lollipop` method for full argument documentation.
+"""
+function lollipop(df, x::Symbol, y::Symbol;
+                  dot_size::Int = 10,
+                  stem_width::Int = 2,
+                  legend::Bool = false,
+                  kwargs...)
+    Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
+    lollipop(_table_col(df, x), _table_col(df, y);
+             dot_size = dot_size, stem_width = stem_width, legend = legend, kwargs...)
+end
+
+"""
+    lollipop(df, x, y, group)
+
+Creates an `EChart` lollipop chart from table `df`, grouping series by the `group` column.
+Legend is displayed by default when a group is provided.
+See the primary `lollipop` method for full argument documentation.
+"""
+function lollipop(df, x::Symbol, y::Symbol, group::Symbol;
+                  dot_size::Int = 10,
+                  stem_width::Int = 2,
+                  legend::Bool = true,
+                  kwargs...)
+    Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
+
+    xvals, mat, group_names = _table_unstack(df, x, group, y)
+    mat_float = map(v -> ismissing(v) ? missing : Float64(v), mat)
+    ec = lollipop(xvals, mat_float; dot_size = dot_size, stem_width = stem_width,
+                  legend = false, kwargs...)
+
+    scatter_idx = [i for (i, s) in enumerate(ec.series) if s._type == "scatter"]
+    for (i, idx) in enumerate(scatter_idx)
+        ec.series[idx].name = group_names[i]
+    end
+    for s in ec.series
+        s._type == "bar" ? s.name = "" : nothing
+    end
+
+    legend ? legend!(ec) : nothing
+    return ec
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -509,3 +509,26 @@ bump_df = DataFrame(
 )
 result_bump_df = bump(bump_df, :year, :sales, :brand)
 @test typeof(result_bump_df) == EChart
+
+# lollipop
+lp_cats = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+lp_vals = [120.0, 200.0, 150.0, 80.0, 110.0]
+result_lollipop = lollipop(lp_cats, lp_vals)
+@test typeof(result_lollipop) == EChart
+@test length(result_lollipop.series) == 2  # stem bar + dot scatter
+@test result_lollipop.series[1]._type == "bar"
+@test result_lollipop.series[2]._type == "scatter"
+
+lp_vals2 = hcat(lp_vals, 0.8 .* lp_vals)
+result_lollipop_multi = lollipop(lp_cats, lp_vals2)
+@test typeof(result_lollipop_multi) == EChart
+@test length(result_lollipop_multi.series) == 4  # 2 stems + 2 dots
+
+lp_df = DataFrame(day = lp_cats, sales = lp_vals)
+@test typeof(lollipop(lp_df, :day, :sales)) == EChart
+
+lp_df2 = DataFrame(day = vcat(lp_cats, lp_cats),
+                   sales = vcat(lp_vals, 0.8 .* lp_vals),
+                   group = vcat(fill("A", 5), fill("B", 5)))
+result_lollipop_grp = lollipop(lp_df2, :day, :sales, :group)
+@test typeof(result_lollipop_grp) == EChart


### PR DESCRIPTION
## Summary

- Adds `lollipop(x, y)` — a dot-and-stem chart that renders each value as a thin bar (stem) with a scatter dot at the tip, reducing visual clutter compared to filled bars
- Supports single-series vectors, 2-D arrays (multi-series), and Tables.jl DataFrames with optional `group` column
- Configurable `dot_size` (default 10 px) and `stem_width` (default 2 px) parameters
- Includes docstring, doc page (`docs/src/charts/lollipop.md`), and tests

## Test plan

- [x] Returns `EChart` with exactly 2 series (bar stem + scatter dot) for single series
- [x] 2-D array produces 4 series (2 stems + 2 dots)
- [x] Stem series type is `"bar"`, dot series type is `"scatter"`
- [x] DataFrame single-column and grouped DataFrame inputs work correctly
- [x] Full test suite passes (`Pkg.test()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)