### PR TITLE
Add slope chart (two-point comparison)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -67,6 +67,7 @@ makedocs(
             "charts/ridgeline.md",
             "charts/sankey.md",
             "charts/scatter.md",
+            "charts/slope.md",
             "charts/single_axis.md",
             "charts/span_chart.md",
             "charts/streamgraph.md",

--- a/docs/src/charts/slope.md
+++ b/docs/src/charts/slope.md
@@ -1,0 +1,31 @@
+# slope
+
+```@docs
+slope
+```
+
+```@example
+using ECharts
+points = ["2015", "2023"]
+# rows = series, columns = time points
+vals = [4.6   3.0;
+        10.4   7.3;
+        22.1  12.2]
+ec = slope(points, vals)
+seriesnames!(ec, ["Germany", "France", "Spain"])
+ec
+```
+
+From a DataFrame:
+
+```@example df
+using ECharts, DataFrames
+df = DataFrame(
+    country   = ["Germany", "France", "Spain", "Italy"],
+    rate_2015 = [4.6, 10.4, 22.1, 11.9],
+    rate_2023 = [3.0,  7.3, 12.2,  6.7],
+)
+ec = slope(df, :country, :rate_2015, :rate_2023)
+title!(ec, text = "Unemployment Rate Change 2015 → 2023")
+ec
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -30,7 +30,7 @@ module ECharts
 	export AxisLine, AxisTick, AxisLabel, SplitLine, SplitArea, MarkLine, MarkArea, MarkPoint
 	export Theme, VisualMap
 
-	export xy_plot, bar, radialbar, polarbar, line, scatter, area, waterfall, lollipop
+	export xy_plot, bar, radialbar, polarbar, line, scatter, area, waterfall, lollipop, slope
 	export bump
 	export box, candlestick, sankey
 	export radar, funnel
@@ -136,6 +136,7 @@ module ECharts
 	include("plots/single_axis.jl")
 	include("plots/bump.jl")
 	include("plots/lollipop.jl")
+	include("plots/slope.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/plots/slope.jl
+++ b/src/plots/slope.jl
@@ -1,0 +1,105 @@
+"""
+    slope(labels, values)
+
+Creates an `EChart` slope chart — a line chart with exactly two x-axis points that
+emphasises the direction and magnitude of change between two states (e.g. before/after,
+two time points, two groups). Each row in `values` (or each series in a DataFrame)
+becomes a labelled slope line.
+
+## Methods
+```julia
+slope(labels::AbstractVector, values::AbstractArray{<:Union{Missing, Real},2})
+slope(df, label::Symbol, before::Symbol, after::Symbol)
+```
+
+## Arguments
+* `left_label::String` : label for the left axis point (default: `string(labels[1])`)
+* `right_label::String` : label for the right axis point (default: `string(labels[2])`)
+* `legend::Bool = true` : display legend?
+* `kwargs` : varargs to set any field of the resulting `EChart` struct
+
+## Notes
+
+`labels` must have exactly two elements — one for the left point and one for the right.
+`values` must have exactly two columns (or `before`/`after` two separate columns for the
+DataFrame method). Each row represents a named series; use `seriesnames!` to set names
+after construction if needed.
+
+# Examples
+```@example
+using ECharts
+points = ["2020", "2023"]
+# Rows = countries, Columns = years
+vals = [72.0  78.0;   # Country A
+        65.0  60.0;   # Country B
+        81.0  85.0]   # Country C
+ec = slope(points, vals)
+seriesnames!(ec, ["Country A", "Country B", "Country C"])
+ec
+```
+"""
+function slope(labels::AbstractVector,
+               values::AbstractArray{<:Union{Missing, Real},2};
+               legend::Bool = true,
+               kwargs...)
+
+    length(labels) == 2 ||
+        throw(ArgumentError("slope charts require exactly 2 labels, got $(length(labels))"))
+    size(values, 2) == 2 ||
+        throw(ArgumentError("slope charts require exactly 2 columns in values, got $(size(values,2))"))
+
+    n_series = size(values, 1)
+    xlabels = string.(labels)
+
+    ec = newplot(kwargs, ec_charttype = "slope")
+    ec.xAxis = [Axis(_type = "category", data = xlabels, boundaryGap = true)]
+    ec.yAxis = [Axis(_type = "value")]
+
+    ec.series = [XYSeries(
+        name  = "Series $i",
+        _type = "line",
+        data  = [values[i, 1], values[i, 2]],
+    ) for i in 1:n_series]
+
+    legend ? legend!(ec) : nothing
+    return ec
+end
+
+"""
+    slope(df, label, before, after)
+
+Creates an `EChart` slope chart from a Tables.jl-compatible table. The `label` column
+provides series names; `before` and `after` are the two value columns.
+See the primary `slope` method for full argument documentation.
+
+# Examples
+```@example df
+using ECharts, DataFrames
+df = DataFrame(
+    country   = ["Germany", "France", "Spain", "Italy"],
+    rate_2015 = [4.6, 10.4, 22.1, 11.9],
+    rate_2023 = [3.0,  7.3, 12.2,  6.7],
+)
+ec = slope(df, :country, :rate_2015, :rate_2023)
+title!(ec, text = "Unemployment Rate Change 2015 → 2023")
+ec
+```
+"""
+function slope(df, label::Symbol, before::Symbol, after::Symbol;
+               legend::Bool = true,
+               kwargs...)
+    Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
+
+    names  = string.(_table_col(df, label))
+    bvals  = _table_col(df, before)
+    avals  = _table_col(df, after)
+    labels = [string(before), string(after)]
+
+    length(names) == length(bvals) == length(avals) ||
+        throw(ArgumentError("label, before, and after columns must have the same length"))
+
+    vals = hcat(bvals, avals)
+    ec = slope(labels, Float64.(vals); legend = legend, kwargs...)
+    seriesnames!(ec, names)
+    return ec
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -532,3 +532,25 @@ lp_df2 = DataFrame(day = vcat(lp_cats, lp_cats),
                    group = vcat(fill("A", 5), fill("B", 5)))
 result_lollipop_grp = lollipop(lp_df2, :day, :sales, :group)
 @test typeof(result_lollipop_grp) == EChart
+
+# slope
+slope_labels = ["2015", "2023"]
+slope_vals = [4.6  3.0;
+              10.4  7.3;
+              22.1 12.2]
+result_slope = slope(slope_labels, slope_vals)
+@test typeof(result_slope) == EChart
+@test length(result_slope.series) == 3
+@test result_slope.xAxis[1]._type == "category"
+
+@test_throws ArgumentError slope(["2015", "2020", "2023"], slope_vals)  # too many labels
+@test_throws ArgumentError slope(slope_labels, hcat(slope_vals, slope_vals[:,1]))  # 3 cols
+
+slope_df = DataFrame(
+    country   = ["Germany", "France", "Spain"],
+    rate_2015 = [4.6, 10.4, 22.1],
+    rate_2023 = [3.0,  7.3, 12.2],
+)
+result_slope_df = slope(slope_df, :country, :rate_2015, :rate_2023)
+@test typeof(result_slope_df) == EChart
+@test result_slope_df.series[1].name == "Germany"


### PR DESCRIPTION
## Summary

- Adds `slope(labels, values)` — a two-point line chart that emphasises direction and magnitude of change between exactly two states (before/after, two years, two groups)
- Matrix method: `labels` must have exactly 2 elements; `values` is an n×2 matrix where each row is a series
- DataFrame method: `slope(df, :label_col, :before_col, :after_col)` automatically names each series from the label column
- Both methods validate input dimensions and throw `ArgumentError` on mismatches
- Includes docstring, doc page (`docs/src/charts/slope.md`), and tests

## Test plan

- [x] `slope(labels, matrix)` returns `EChart` with correct series count and category x-axis
- [x] `ArgumentError` thrown for wrong number of labels or value columns
- [x] DataFrame method sets series names from the label column
- [x] Full test suite passes (`Pkg.test()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)