### PR TITLE
Add marimekko (mosaic) chart with CustomSeries type

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -55,6 +55,7 @@ makedocs(
             "charts/histogram.md",
             "charts/line.md",
             "charts/lollipop.md",
+            "charts/marimekko.md",
             "charts/nightingale.md",
             "charts/parallel.md",
             "charts/pie.md",

--- a/docs/src/charts/marimekko.md
+++ b/docs/src/charts/marimekko.md
@@ -1,0 +1,29 @@
+# marimekko
+
+```@docs
+marimekko
+```
+
+```@example
+using ECharts
+categories    = ["North", "South", "East", "West"]
+subcategories = ["Product A", "Product B", "Product C"]
+values = [40.0  30.0  20.0  10.0;
+          25.0  35.0  15.0  25.0;
+          35.0  35.0  65.0  65.0]
+marimekko(categories, subcategories, values)
+```
+
+From a DataFrame (long format):
+
+```@example df
+using ECharts, DataFrames
+df = DataFrame(
+    region  = repeat(["North","South","East","West"], inner = 3),
+    product = repeat(["A","B","C"], outer = 4),
+    revenue = [40, 25, 35, 30, 35, 35, 20, 15, 65, 10, 25, 65],
+)
+ec = marimekko(df, :region, :product, :revenue)
+title!(ec, text = "Revenue by Region and Product")
+ec
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -21,7 +21,7 @@ module ECharts
 	export colorpalettes
 
 	export EChart, EChartRaw, echart, @echart
-	export BoxPlotSeries, CandleStickSeries, ChordSeries, EffectScatterSeries, FunnelSeries, GaugeSeries, GraphSeries,
+	export BoxPlotSeries, CandleStickSeries, ChordSeries, CustomSeries, EffectScatterSeries, FunnelSeries, GaugeSeries, GraphSeries,
 	HeatmapSeries, LinesSeries, MapSeries, ParallelSeries, PictorialBarSeries, PieSeries, RadarSeries,
 	SankeySeries, SunburstSeries, ThemeRiverSeries, TreeSeries, TreemapSeries, XYSeries
 	export Title, Axis, Toolbox, DataZoom
@@ -30,7 +30,7 @@ module ECharts
 	export AxisLine, AxisTick, AxisLabel, SplitLine, SplitArea, MarkLine, MarkArea, MarkPoint
 	export Theme, VisualMap
 
-	export xy_plot, bar, radialbar, polarbar, line, scatter, area, waterfall, lollipop, slope
+	export xy_plot, bar, radialbar, polarbar, line, scatter, area, waterfall, lollipop, slope, marimekko
 	export bump
 	export box, candlestick, sankey
 	export radar, funnel
@@ -137,6 +137,7 @@ module ECharts
 	include("plots/bump.jl")
 	include("plots/lollipop.jl")
 	include("plots/slope.jl")
+	include("plots/marimekko.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/definetypes.jl
+++ b/src/definetypes.jl
@@ -1626,6 +1626,31 @@ This is the series type used internally by [`bar`](@ref), [`line`](@ref), [`scat
     largeThreshold::Union{Int, Nothing} = nothing
 end
 """
+    CustomSeries
+
+ECharts series configuration for custom-rendered charts. The `renderItem` field accepts
+a `JSON.JSONText`-wrapped JavaScript function string that ECharts calls for each data
+point to produce SVG/canvas primitives (rect, circle, etc.).
+
+Used internally by [`marimekko`](@ref).
+"""
+@with_kw mutable struct CustomSeries <: AbstractEChartSeries
+    _type::String = "custom"
+    name::Union{String, Nothing} = nothing
+    renderItem::Union{JSON.JSONText, Nothing} = nothing
+    itemStyle::Union{ItemStyle, Nothing} = nothing
+    label::Union{Label, Nothing} = nothing
+    encode::Union{Dict, Nothing} = nothing
+    data::Union{AbstractVector, Nothing} = nothing
+    xAxisIndex::Union{Int, Nothing} = nothing
+    yAxisIndex::Union{Int, Nothing} = nothing
+    zlevel::Union{Int, Nothing} = nothing
+    z::Union{Int, Nothing} = nothing
+    silent::Union{Bool, Nothing} = nothing
+    animation::Union{Bool, Nothing} = nothing
+    tooltip::Union{Tooltip, Nothing} = nothing
+end
+"""
     EChart
 
 The main chart struct returned by all ECharts.jl chart constructors (e.g. [`bar`](@ref),

--- a/src/plots/marimekko.jl
+++ b/src/plots/marimekko.jl
@@ -1,0 +1,157 @@
+"""
+    marimekko(categories, subcategories, values)
+
+Creates an `EChart` Marimekko chart (also called a mosaic plot) — a two-dimensional
+stacked chart where **column widths** are proportional to each category's share of the
+total, and **stacked heights** within each column show the sub-category composition.
+
+## Methods
+```julia
+marimekko(categories::AbstractVector,
+          subcategories::AbstractVector,
+          values::AbstractArray{<:Real,2})
+```
+
+## Arguments
+* `categories` : column labels (length `n_cols`)
+* `subcategories` : row/segment labels (length `n_rows`)
+* `values` : matrix of shape `(n_rows, n_cols)` — rows are sub-categories, columns are
+  categories. Values must be non-negative; they are normalised internally.
+* `legend::Bool = true` : display legend?
+* `kwargs` : varargs to set any field of the resulting `EChart` struct
+
+## Notes
+
+Column widths are proportional to each column's share of the grand total, scaled to
+0–100 on the X-axis. Within each column, values are stacked to fill 0–100 on the Y-axis.
+Both axes display percentage labels.
+
+Rendering uses ECharts' `custom` series type with a `renderItem` JavaScript function that
+draws one rectangle per cell. One `CustomSeries` is created per sub-category row.
+
+# Examples
+```@example
+using ECharts
+categories    = ["North", "South", "East", "West"]
+subcategories = ["Product A", "Product B", "Product C"]
+values = [40.0  30.0  20.0  10.0;   # Product A share per region
+          25.0  35.0  15.0  25.0;   # Product B
+          35.0  35.0  65.0  65.0]   # Product C
+marimekko(categories, subcategories, values)
+```
+"""
+function marimekko(categories::AbstractVector,
+                   subcategories::AbstractVector,
+                   values::AbstractArray{<:Real,2};
+                   legend::Bool = true,
+                   kwargs...)
+
+    n_rows, n_cols = size(values)
+    length(categories) == n_cols ||
+        throw(ArgumentError("length of categories ($(length(categories))) must equal " *
+                            "number of columns in values ($n_cols)"))
+    length(subcategories) == n_rows ||
+        throw(ArgumentError("length of subcategories ($(length(subcategories))) must equal " *
+                            "number of rows in values ($n_rows)"))
+    all(values .>= 0) ||
+        throw(ArgumentError("all values must be non-negative"))
+
+    # Column widths: each column's share of the grand total (0–100 scale)
+    col_totals = sum(values, dims = 1)[:]
+    grand_total = sum(col_totals)
+    grand_total > 0 || throw(ArgumentError("grand total of values must be positive"))
+
+    col_widths = col_totals ./ grand_total .* 100.0
+    col_starts = [0.0; cumsum(col_widths)[1:end-1]]
+
+    # Within each column, normalise rows to percentages (0–100 scale)
+    pct = zeros(Float64, n_rows, n_cols)
+    for j in 1:n_cols
+        ct = col_totals[j]
+        for i in 1:n_rows
+            pct[i, j] = ct > 0 ? values[i, j] / ct * 100.0 : 0.0
+        end
+    end
+
+    # renderItem JS function: data[i] = [x_start, y_start, x_end, y_end]
+    render_fn = JSON.JSONText("""
+function(params, api) {
+    var x0 = api.coord([api.value(0), api.value(3)]);
+    var x1 = api.coord([api.value(2), api.value(1)]);
+    return {
+        type: 'rect',
+        shape: {
+            x: x0[0],
+            y: x0[1],
+            width: x1[0] - x0[0],
+            height: x1[1] - x0[1]
+        },
+        style: api.style()
+    };
+}
+""")
+
+    series = CustomSeries[]
+    for i in 1:n_rows
+        cell_data = Vector{Vector{Float64}}(undef, n_cols)
+        cum_y = zeros(Float64, n_cols)
+        # accumulate heights for rows above i
+        for ii in 1:(i-1)
+            for j in 1:n_cols
+                cum_y[j] += pct[ii, j]
+            end
+        end
+        for j in 1:n_cols
+            x_start = col_starts[j]
+            x_end   = col_starts[j] + col_widths[j]
+            y_start = cum_y[j]
+            y_end   = cum_y[j] + pct[i, j]
+            cell_data[j] = [x_start, y_start, x_end, y_end]
+        end
+        push!(series, CustomSeries(
+            name       = string(subcategories[i]),
+            renderItem = render_fn,
+            data       = cell_data,
+            encode     = Dict("x" => [0, 2], "y" => [1, 3]),
+        ))
+    end
+
+    ec = newplot(kwargs, ec_charttype = "marimekko")
+    ec.xAxis = [Axis(_type = "value", min = 0, max = 100,
+                     axisLabel = AxisLabel(formatter = "{value}%"))]
+    ec.yAxis = [Axis(_type = "value", min = 0, max = 100,
+                     axisLabel = AxisLabel(formatter = "{value}%"))]
+    ec.series = series
+
+    legend ? legend!(ec) : nothing
+    return ec
+end
+
+"""
+    marimekko(df, category, subcategory, value)
+
+Creates an `EChart` Marimekko chart from a Tables.jl-compatible table in long format.
+The `category` column defines the columns (variable-width axis), `subcategory` defines
+the stacked segments, and `value` holds the cell magnitudes.
+See the primary `marimekko` method for full argument documentation.
+
+# Examples
+```@example df
+using ECharts, DataFrames
+df = DataFrame(
+    region   = repeat(["North","South","East","West"], inner = 3),
+    product  = repeat(["A","B","C"], outer = 4),
+    revenue  = [40, 25, 35, 30, 35, 35, 20, 15, 65, 10, 25, 65],
+)
+marimekko(df, :region, :product, :revenue)
+```
+"""
+function marimekko(df, category::Symbol, subcategory::Symbol, value::Symbol;
+                   legend::Bool = true,
+                   kwargs...)
+    Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
+
+    cats, mat, sub_names = _table_unstack(df, category, subcategory, value)
+    mat_float = Float64.(coalesce.(mat, 0.0))
+    marimekko(cats, sub_names, mat_float'; legend = legend, kwargs...)
+end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -554,3 +554,29 @@ slope_df = DataFrame(
 result_slope_df = slope(slope_df, :country, :rate_2015, :rate_2023)
 @test typeof(result_slope_df) == EChart
 @test result_slope_df.series[1].name == "Germany"
+
+# marimekko
+mm_cats = ["North", "South", "East", "West"]
+mm_subs = ["Product A", "Product B", "Product C"]
+mm_vals = [40.0 30.0 20.0 10.0;
+           25.0 35.0 15.0 25.0;
+           35.0 35.0 65.0 65.0]
+result_marimekko = marimekko(mm_cats, mm_subs, mm_vals)
+@test typeof(result_marimekko) == EChart
+@test length(result_marimekko.series) == 3  # one CustomSeries per subcategory
+@test result_marimekko.series[1]._type == "custom"
+@test result_marimekko.series[1].name == "Product A"
+@test result_marimekko.xAxis[1]._type == "value"
+
+@test_throws ArgumentError marimekko(["A", "B"], mm_subs, mm_vals)  # wrong categories length
+@test_throws ArgumentError marimekko(mm_cats, ["X"], mm_vals)        # wrong subcategories length
+@test_throws ArgumentError marimekko(mm_cats, mm_subs, -1 .* mm_vals) # negative values
+
+mm_df = DataFrame(
+    region  = repeat(["North","South","East","West"], inner = 3),
+    product = repeat(["A","B","C"], outer = 4),
+    revenue = [40.0, 25.0, 35.0, 30.0, 35.0, 35.0, 20.0, 15.0, 65.0, 10.0, 25.0, 65.0],
+)
+result_marimekko_df = marimekko(mm_df, :region, :product, :revenue)
+@test typeof(result_marimekko_df) == EChart
+@test length(result_marimekko_df.series) == 3


### PR DESCRIPTION
## Summary

- Adds `CustomSeries` to `definetypes.jl` — a new series type for ECharts' `custom` render mode, with a `renderItem::JSON.JSONText` field for embedding JavaScript render functions. Exported as `CustomSeries`.
- Adds `marimekko(categories, subcategories, values)` — a mosaic/Marimekko chart where:
  - **Column widths** are proportional to each category's share of the grand total (X-axis 0–100%)
  - **Stacked heights** within each column show the sub-category composition (Y-axis 0–100%)
  - One `CustomSeries` per sub-category row, each drawing rectangles via a `renderItem` JS function
- Also includes a DataFrame long-format method: `marimekko(df, :category, :subcategory, :value)`
- Input validation: mismatched dimensions and negative values throw `ArgumentError`

## Test plan

- [x] Returns `EChart` with one `CustomSeries` per sub-category (`_type == "custom"`)
- [x] Series names match `subcategories` input
- [x] X-axis is `"value"` type (0–100 scale)
- [x] `ArgumentError` thrown for wrong `categories` length, wrong `subcategories` length, and negative values
- [x] DataFrame long-format input produces correct series count
- [x] Full test suite passes (`Pkg.test()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)