### PR TITLE
Fix duplicate chart IDs causing beeswarm docs not to render

### DIFF
--- a/src/plots/beeswarm.jl
+++ b/src/plots/beeswarm.jl
@@ -11,7 +11,7 @@ beeswarm(categories::AbstractVector, values::AbstractVector{<:Real})
 
 ## Arguments
 * `jitter_width::Real = 0.3` : half-width of the uniform jitter range (in category units)
-* `legend::Bool = false` : display legend?
+* `legend::Bool = true` : display legend?
 * `kwargs` : varargs to set any field of resulting `EChart` struct
 
 ## Notes
@@ -24,7 +24,7 @@ distinct color from the active theme palette.
 """
 function beeswarm(categories::AbstractVector, values::AbstractVector{<:Real};
                   jitter_width::Real = 0.3,
-                  legend::Bool = false,
+                  legend::Bool = true,
                   kwargs...)
 
     cat_labels = unique(categories)
@@ -63,7 +63,7 @@ See the primary `beeswarm` method for full argument documentation.
 """
 function beeswarm(df, categories::Symbol, values::Symbol;
                   jitter_width::Real = 0.3,
-                  legend::Bool = false,
+                  legend::Bool = true,
                   kwargs...)
     Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
     beeswarm(_table_col(df, categories), _table_col(df, values);

--- a/src/render.jl
+++ b/src/render.jl
@@ -1,3 +1,5 @@
+const _chart_id_counter = Threads.Atomic{Int}(0)
+
 """
     EChartRaw
 
@@ -51,7 +53,7 @@ print(x::EChartRaw) = print(x.option)
 # Internal: shared HTML template used by both EChart and EChartRaw renderers.
 function _echarts_html(option::String, width, height, renderer::String, theme)
     theme_json = JSON.json(theme)
-    chart_id = "echarts_" * string(rand(UInt64), base = 16)
+    chart_id = "echarts_" * string(Threads.atomic_add!(_chart_id_counter, 1))
 
     # When ECHARTS_DOCS_BUILD is set, echarts.min.js is loaded as a page asset
     # by Documenter.jl — skip inlining it to avoid bloating the output.


### PR DESCRIPTION
## Summary

- Replaces `rand(UInt64)` with a thread-safe atomic counter for generating chart div IDs in `_echarts_html`
- Sets `beeswarm` legend default to `true` to match other chart types

## Root cause

`_echarts_html` called `rand(UInt64)` to produce a unique HTML element ID for each chart. When two `@example` blocks in docs both call `Random.seed!(42)` and then execute the same sequence of RNG operations (same data generation, same beeswarm jitter), the global RNG is in an identical state by the time `_echarts_html` runs — producing **the same ID for both charts**. The second chart's JavaScript silently fails to initialize because `echarts.init` is called on an already-initialized element.

## Fix

Replace `rand(UInt64)` with `Threads.atomic_add!(_chart_id_counter, 1)` — a module-level atomic counter that increments monotonically. Chart IDs are now `echarts_0`, `echarts_1`, etc., guaranteed unique regardless of RNG state or seeding.

## Test plan

- [ ] Build docs locally and confirm beeswarm page shows two distinct charts
- [ ] Verify both `echarts_N` div IDs in the rendered HTML are different

🤖 Generated with [Claude Code](https://claude.com/claude-code)