### PR TITLE
Fix docstring/signature mismatches across plot functions

### DIFF
--- a/src/plots/arc_diagram.jl
+++ b/src/plots/arc_diagram.jl
@@ -16,7 +16,6 @@ arcdiagram(nodes::AbstractVector{String}, links::AbstractVector,
 * `curveness::Real = 0.4` : edge curvature (0 = straight, 1 = very curved)
 * `symbol_size::Int = 20` : node circle diameter in pixels
 * `roam::Bool = false` : allow panning and zooming?
-* `max_width::Int = 8` : maximum edge line width when weights are provided
 * `legend::Bool = false` : display legend?
 * `kwargs` : varargs to set any field of the resulting `EChart` struct
 

--- a/src/plots/bar.jl
+++ b/src/plots/bar.jl
@@ -12,8 +12,7 @@ bar(df, x::Symbol, y::Symbol, group::Symbol)
 ```
 
 ## Arguments
-* `mark::Union{String, AbstractVector} = "bar"` : how to display plotted points
-* `stack::Union{Bool, AbstractVector, Void} = nothing` : stack (add together) when multple series present?
+* `stack::Union{Bool, AbstractVector, Nothing} = nothing` : stack (add together) when multiple series present?
 * `legend::Bool` : display legend?
 * `scale::Bool = false` : show full Y-axis or truncated
 * `kwargs` : varargs to set any field of resulting `EChart` struct
@@ -23,13 +22,12 @@ bar(df, x::Symbol, y::Symbol, group::Symbol)
 Reasonable defaults set for different methods of `bar`, such as displaying a legend when two or more series present.
 """
 function bar(x::AbstractVector, y::AbstractVector{<:Union{Missing, Real}};
-			mark::Union{String, AbstractVector} = "bar",
 			stack::Union{Bool, AbstractVector, Nothing} = nothing,
 			legend::Bool = false,
 			scale::Bool = false,
 			kwargs...)
 
-	 return xy_plot(x, y; mark = mark, stack = stack, legend = legend, scale = scale, kwargs...)
+	 return xy_plot(x, y; mark = "bar", stack = stack, legend = legend, scale = scale, kwargs...)
 
 end
 
@@ -41,13 +39,12 @@ Legend is displayed by default when multiple series are present.
 See the primary `bar` method for full argument documentation.
 """
 function bar(x::AbstractVector, y::AbstractArray{<:Union{Missing, Real},2};
-			mark::Union{String, AbstractVector} = "bar",
 			stack::Union{Bool, AbstractVector, Nothing} = nothing,
 			legend::Bool = true,
 			scale::Bool = false,
 			kwargs...)
 
-	 return xy_plot(x, y; mark = mark, stack = stack, legend = legend, scale = scale, kwargs...)
+	 return xy_plot(x, y; mark = "bar", stack = stack, legend = legend, scale = scale, kwargs...)
 
 end
 
@@ -58,14 +55,13 @@ Creates an `EChart` bar chart from a single column `y` in table `df` against col
 See the primary `bar` method for full argument documentation.
 """
 function bar(df, x::Symbol, y::Symbol;
-			mark::Union{String, AbstractVector} = "bar",
 			stack::Union{Bool, AbstractVector, Nothing} = nothing,
 			legend::Bool = false,
 			scale::Bool = false,
 			kwargs...)
 
 	 Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
-	 return xy_plot(df, x, y; mark = mark, stack = stack, legend = legend, scale = scale, kwargs...)
+	 return xy_plot(df, x, y; mark = "bar", stack = stack, legend = legend, scale = scale, kwargs...)
 
 end
 
@@ -77,13 +73,12 @@ Legend is displayed by default when a group is provided.
 See the primary `bar` method for full argument documentation.
 """
 function bar(df, x::Symbol, y::Symbol, group::Symbol;
-			mark::Union{String, AbstractVector} = "bar",
 			stack::Union{Bool, AbstractVector, Nothing} = nothing,
 			legend::Bool = true,
 			scale::Bool = false,
 			kwargs...)
 
 	 Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
-	 return xy_plot(df, x, y, group; mark = mark, stack = stack, legend = legend, scale = scale, kwargs...)
+	 return xy_plot(df, x, y, group; mark = "bar", stack = stack, legend = legend, scale = scale, kwargs...)
 
 end

--- a/src/plots/corrplot.jl
+++ b/src/plots/corrplot.jl
@@ -17,7 +17,9 @@ corrplot(df)
 * `number_digits::Int = 2` : decimal places shown in correlation labels
 * `label_color::String = "black"` : text color of correlation labels
 * `label_fontsize::Int = 14` : font size of correlation labels
-* `order::String = "original"` : column ordering for table input; one of {"original", "alphabet"}
+* `ec_height::Real = 650` : chart height in pixels
+* `ec_width::Real = 650` : chart width in pixels
+* `order::String = "original"` : column ordering; one of {"original", "alphabet"} (table input only)
 * `kwargs` : varargs to set any field of resulting `EChart` struct
 
 ## Notes

--- a/src/plots/funnel.jl
+++ b/src/plots/funnel.jl
@@ -9,6 +9,7 @@ funnel(names::AbstractVector, values::AbstractVector{<:Union{Missing, Real}})
 ```
 
 ## Arguments
+* `sort::String = "descending"` : sort order for funnel slices; one of {"descending", "ascending", "none"}
 * `legend::Bool` : display legend?
 * `kwargs` : varargs to set any field of resulting `EChart` struct
 

--- a/src/plots/radialbar.jl
+++ b/src/plots/radialbar.jl
@@ -12,8 +12,7 @@ radialbar(df, x::Symbol, y::Symbol, group::Symbol)
 ```
 
 ## Arguments
-* `mark::Union{String, AbstractVector} = "bar"` : how to display plotted points
-* `stack::Union{Bool, AbstractVector, Void} = nothing` : stack (add together) when multple series present?
+* `stack::Union{Bool, AbstractVector, Nothing} = nothing` : stack (add together) when multiple series present?
 * `legend::Bool` : display legend?
 * `scale::Bool = false` : show full Y-axis or truncated
 * `kwargs` : varargs to set any field of resulting `EChart` struct
@@ -21,13 +20,12 @@ radialbar(df, x::Symbol, y::Symbol, group::Symbol)
 ## Notes
 """
 function radialbar(x::AbstractVector, y::AbstractVector{<:Union{Missing, Real}};
-			mark::Union{String, AbstractVector} = "bar",
 			stack::Union{Bool, AbstractVector, Nothing} = nothing,
 			legend::Bool = false,
 			scale::Bool = false,
 			kwargs...)
 
-	 ec = bar(x, y; mark = mark, stack = stack, legend = legend, scale = scale, kwargs...)
+	 ec = bar(x, y; stack = stack, legend = legend, scale = scale, kwargs...)
 	 radial!(ec)
 
 	 return ec
@@ -41,13 +39,12 @@ Legend is displayed by default when multiple series are present.
 See the primary `radialbar` method for full argument documentation.
 """
 function radialbar(x::AbstractVector, y::AbstractArray{<:Union{Missing, Real},2};
-			mark::Union{String, AbstractVector} = "bar",
 			stack::Union{Bool, AbstractVector, Nothing} = nothing,
 			legend::Bool = true,
 			scale::Bool = false,
 			kwargs...)
 
-	 ec = bar(x, y; mark = mark, stack = stack, legend = legend, scale = scale, kwargs...)
+	 ec = bar(x, y; stack = stack, legend = legend, scale = scale, kwargs...)
 	 radial!(ec)
 
 	 return ec
@@ -60,14 +57,13 @@ Creates an `EChart` radial bar chart from a single column `y` in table `df` agai
 See the primary `radialbar` method for full argument documentation.
 """
 function radialbar(df, x::Symbol, y::Symbol;
-			mark::Union{String, AbstractVector} = "bar",
 			stack::Union{Bool, AbstractVector, Nothing} = nothing,
 			legend::Bool = false,
 			scale::Bool = false,
 			kwargs...)
 
 	 Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
-	 ec = bar(df, x, y; mark = mark, stack = stack, legend = legend, scale = scale, kwargs...)
+	 ec = bar(df, x, y; stack = stack, legend = legend, scale = scale, kwargs...)
 	 radial!(ec)
 
 	 return ec
@@ -81,14 +77,13 @@ Legend is displayed by default when a group is provided.
 See the primary `radialbar` method for full argument documentation.
 """
 function radialbar(df, x::Symbol, y::Symbol, group::Symbol;
-			mark::Union{String, AbstractVector} = "bar",
 			stack::Union{Bool, AbstractVector, Nothing} = nothing,
 			legend::Bool = true,
 			scale::Bool = false,
 			kwargs...)
 
 	 Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
-	 ec = bar(df, x, y, group; mark = mark, stack = stack, legend = legend, scale = scale, kwargs...)
+	 ec = bar(df, x, y, group; stack = stack, legend = legend, scale = scale, kwargs...)
 	 radial!(ec)
 
 	 return ec

--- a/src/plots/slope.jl
+++ b/src/plots/slope.jl
@@ -13,8 +13,6 @@ slope(df, label::Symbol, before::Symbol, after::Symbol)
 ```
 
 ## Arguments
-* `left_label::String` : label for the left axis point (default: `string(labels[1])`)
-* `right_label::String` : label for the right axis point (default: `string(labels[2])`)
 * `legend::Bool = true` : display legend?
 * `kwargs` : varargs to set any field of the resulting `EChart` struct
 


### PR DESCRIPTION
## Summary

- **`bar`/`radialbar`**: Remove `mark` kwarg from signatures (hardcode `"bar"`). `bar` always produces a bar chart, so exposing `mark` allowed nonsensical calls like `bar(x, y, mark="line")`.
- **`slope`**: Remove `left_label`/`right_label` from docstring — those parameters don't exist in the function signature.
- **`arc_diagram`**: Remove `max_width` from the primary (unweighted) docstring — it only exists in the `arcdiagram(nodes, links, weights)` method.
- **`corrplot`**: Add missing `ec_height`/`ec_width` to docstring; clarify `order` only applies to table input.
- **`funnel`**: Add missing `sort` kwarg to docstring.

## Test plan

- [ ] Verify `bar(x, y)` and `bar(df, x, y)` still produce bar charts
- [ ] Verify `radialbar` still works
- [ ] Confirm `bar(x, y, mark="line")` now errors (breaking change, intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)