### PR TITLE
Fix linreg! confidence interval band rendering

### DIFF
--- a/docs/src/charts/scatter.md
+++ b/docs/src/charts/scatter.md
@@ -19,3 +19,14 @@ ec = scatter(df, :height, :weight, :sex)
 title!(ec, text = "Height vs Weight", subtext = "20 subjects by sex (cm, kg)")
 ec
 ```
+
+```@example
+using ECharts, Random
+Random.seed!(42)
+x = collect(1.0:0.5:10.0)
+y = 1.8 .* x .+ 3.0 .+ randn(length(x)) .* 2
+ec = scatter(x, y)
+linreg!(ec, x, y; annotation = true)
+title!(ec, text = "Simple Linear Regression", subtext = "OLS fit with 95% CI")
+ec
+```

--- a/src/plots/linreg.jl
+++ b/src/plots/linreg.jl
@@ -73,29 +73,22 @@ function linreg!(ec::EChart,
     se_fit = [s * sqrt(1/n + (xi - x_bar)^2 / sxx) for xi in xgrid]
 
     if ci && s > 0
-        lo_pts  = [[xgrid[i], y_fit[i] - z * se_fit[i]] for i in eachindex(xgrid)]
-        hi_diff = [2 * z * se_fit[i] for i in eachindex(xgrid)]
+        # Closed-polygon approach: trace upper CI left→right, then lower CI right→left.
+        # ECharts fills the interior (the CI band) via the canvas non-zero winding rule.
+        # This avoids ECharts stacking, which does not work correctly for [x, y] pair
+        # data on a value axis (as opposed to scalar data on a category axis).
+        upper_pts = [[xgrid[i], y_fit[i] + z * se_fit[i]] for i in eachindex(xgrid)]
+        lower_pts = [[xgrid[i], y_fit[i] - z * se_fit[i]] for i in reverse(eachindex(xgrid))]
 
         push!(ec.series, XYSeries(
             name            = "",
             _type           = "line",
-            data            = lo_pts,
+            data            = vcat(upper_pts, lower_pts),
             lineStyle       = LineStyle(width = 0),
-            showSymbol      = false,
-            legendHoverLink = false,
-            silent          = true,
-            stack           = "ci_band",
-        ))
-        push!(ec.series, XYSeries(
-            name            = "",
-            _type           = "line",
-            data            = [[xgrid[i], hi_diff[i]] for i in eachindex(xgrid)],
-            lineStyle       = LineStyle(width = 0),
-            showSymbol      = false,
             areaStyle       = AreaStyle(color = ci_color, opacity = ci_opacity),
+            showSymbol      = false,
             legendHoverLink = false,
             silent          = true,
-            stack           = "ci_band",
         ))
     end
 


### PR DESCRIPTION
## Summary

- **Root cause**: `linreg!` used ECharts stacking to draw the CI band, which only works for scalar data on category axes. With `[x, y]` pair data on a value axis (scatter charts), ECharts ignores the stack and renders each series at its raw y-values. The `hi_diff` delta series (~1.5–2.9 wide) rendered near y=0, placing the entire CI band below the regression line and data.
- **Fix**: Replace the two-series stacking approach with a single closed-polygon series — upper CI traced left→right, lower CI right→left. ECharts fills the interior correctly via the canvas non-zero winding rule.
- **Docs example**: Added `Random.seed!(42)` and stored `x`/`y` as named variables so both `scatter` and `linreg!` receive identical data and the chart is reproducible across doc builds.

## Test plan

- [ ] Build docs (`ECHARTS_DOCS_BUILD=true julia --project=docs/ docs/make.jl`) and visually confirm the CI band in `charts/scatter.html` and `functions/linreg!.html` is a shaded region centered on the regression line, narrower at the center and wider at the endpoints
- [ ] Confirm the CI band is not visible below the data

🤖 Generated with [Claude Code](https://claude.com/claude-code)