### PR TITLE
Add pictorialbar chart type

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -68,6 +68,7 @@ makedocs(
             "charts/marimekko.md",
             "charts/nightingale.md",
             "charts/parallel.md",
+            "charts/pictorialbar.md",
             "charts/pie.md",
             "charts/polar.md",
             "charts/polarbar.md",

--- a/docs/src/charts/pictorialbar.md
+++ b/docs/src/charts/pictorialbar.md
@@ -1,0 +1,37 @@
+# pictorialbar
+
+```@docs
+pictorialbar
+```
+
+```@example
+using ECharts
+browsers = ["Chrome", "Firefox", "Safari", "Edge", "Other"]
+share    = [65, 15, 10, 6, 4]
+ec = pictorialbar(browsers, share, symbol = "diamond")
+title!(ec, text = "Browser Market Share", subtext = "Illustrative data")
+ec
+```
+
+```@example
+using ECharts
+categories = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+steps      = [8200, 6500, 9100, 7300, 11000, 13500, 5800]
+ec = pictorialbar(categories, steps,
+                  symbol = "path://M0,10 L5,0 L10,10 Z",
+                  symbolRepeat = true,
+                  symbolBoundingData = 15000)
+title!(ec, text = "Daily Step Count", subtext = "Repeating symbol mode")
+ec
+```
+
+```@example
+using ECharts, DataFrames
+df = DataFrame(
+    planet   = ["Mercury", "Venus", "Earth", "Mars"],
+    diameter = [4879, 12104, 12756, 6792],
+)
+ec = pictorialbar(df, :planet, :diameter, symbol = "circle", horizontal = true)
+title!(ec, text = "Planet Diameters (km)")
+ec
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -35,7 +35,7 @@ module ECharts
 	export xy_plot, bar, radialbar, polarbar, line, scatter, area, waterfall, lollipop, slope, marimekko, facet, facet!
 	export bump
 	export box, candlestick, sankey
-	export radar, funnel
+	export radar, funnel, pictorialbar
 	export pie, donut, gauge, polar
 	export histogram, heatmap, streamgraph, bubble
 	export corrplot
@@ -124,6 +124,7 @@ module ECharts
 	include("plots/gauge.jl")
 	include("plots/polar.jl")
 	include("plots/funnel.jl")
+	include("plots/pictorialbar.jl")
 	include("plots/waterfall.jl")
 	include("plots/box.jl")
 	include("plots/candlestick.jl")

--- a/src/definetypes.jl
+++ b/src/definetypes.jl
@@ -1098,7 +1098,7 @@ ECharts series configuration for pictorial bar charts (bars shaped like custom s
     barGap::Union{Int, String, Nothing} = nothing
     barCategoryGap::Union{Int, String, Nothing} = nothing
     symbol::Union{String, Nothing} = nothing
-    symbolSize::Union{AbstractVector, Nothing} = nothing
+    symbolSize::Union{Number, AbstractVector, Nothing} = nothing
     symbolPosition::Union{String, Nothing} = nothing
     symbolOffset::Union{AbstractVector, Nothing} = nothing
     symbolRotate::Union{Int, Nothing} = nothing
@@ -1106,7 +1106,7 @@ ECharts series configuration for pictorial bar charts (bars shaped like custom s
     symbolRepeatDirection::Union{String, Nothing} = nothing
     symbolMargin::Union{Int, String, Nothing} = nothing
     symbolClip::Union{Bool, Nothing} = nothing
-    symbolBoundingData::Union{Int, AbstractArray, Nothing} = nothing
+    symbolBoundingData::Union{Number, AbstractArray, Nothing} = nothing
     symbolPatternSize::Union{Int, Nothing} = nothing
     dimensions::Union{AbstractArray, Nothing} = nothing
     encode::Union{Dict, Nothing} = nothing

--- a/src/plots/pictorialbar.jl
+++ b/src/plots/pictorialbar.jl
@@ -1,0 +1,92 @@
+"""
+    pictorialbar(x, y)
+
+Creates an `EChart` pictorial bar chart, where bars are rendered using a custom symbol
+(icon, shape, or SVG path) instead of plain rectangles.
+
+## Methods
+```julia
+pictorialbar(x::AbstractVector, y::AbstractVector{<:Union{Missing, Real}})
+pictorialbar(df, x::Symbol, y::Symbol)
+```
+
+## Arguments
+* `symbol::Union{String, AbstractVector} = "roundRect"` : symbol shape for all bars, or a vector of shapes (one per bar). Built-in shapes: `"circle"`, `"rect"`, `"roundRect"`, `"triangle"`, `"diamond"`, `"pin"`, `"arrow"`. Also accepts SVG paths (`"path://..."`) and image URLs (`"image://..."`).
+* `symbolSize::Union{Number, AbstractVector, Nothing} = nothing` : symbol size as a number (uniform) or `[width, height]` vector. When `nothing`, ECharts scales the symbol to fill the bar.
+* `symbolRepeat::Union{Bool, Int, String, Nothing} = false` : `false` — single symbol scaled to bar value; `true` — repeat symbols to fill bar height; `"fixed"` — repeat with a fixed symbol size.
+* `symbolBoundingData::Union{Number, Nothing} = nothing` : the maximum data value used as the bounding reference when repeating symbols. Useful for aligning bars with different values.
+* `horizontal::Bool = false` : flip axes to produce a horizontal chart.
+* `legend::Bool = false` : display legend?
+* `kwargs` : varargs to set any field of the resulting `EChart` struct.
+
+## Notes
+
+When `symbol` is a vector, each element sets the shape for the corresponding bar, enabling
+mixed-symbol charts (e.g., different icons for different categories).
+
+Built-in ECharts symbol names (case-sensitive): `"circle"`, `"rect"`, `"roundRect"`,
+`"triangle"`, `"diamond"`, `"pin"`, `"arrow"`, `"none"`.
+"""
+function pictorialbar(x::AbstractVector, y::AbstractVector{<:Union{Missing, Real}};
+                      symbol::Union{String, AbstractVector} = "roundRect",
+                      symbolSize::Union{Number, AbstractVector, Nothing} = nothing,
+                      symbolRepeat::Union{Bool, Int, String, Nothing} = false,
+                      symbolBoundingData::Union{Number, Nothing} = nothing,
+                      horizontal::Bool = false,
+                      legend::Bool = false,
+                      kwargs...)
+
+    length(x) == length(y) || throw(ArgumentError("x and y must have the same length"))
+    if symbol isa AbstractVector
+        length(symbol) == length(y) ||
+            throw(ArgumentError("symbol vector must have the same length as y"))
+    end
+
+    ec = newplot(kwargs, ec_charttype = "pictorialbar")
+    ec.xAxis = [Axis(_type = "category", data = collect(string.(x)))]
+    ec.yAxis = [Axis(_type = "value")]
+
+    # When symbol is a vector, embed per-point symbol in the data array
+    if symbol isa AbstractVector
+        data = [Dict("value" => v, "symbol" => s) for (v, s) in zip(y, symbol)]
+        series_symbol = nothing
+    else
+        data = collect(y)
+        series_symbol = symbol
+    end
+
+    ec.series = [PictorialBarSeries(
+        name               = "Series 1",
+        data               = data,
+        symbol             = series_symbol,
+        symbolSize         = symbolSize isa Number ? [symbolSize, symbolSize] : symbolSize,
+        symbolRepeat       = symbolRepeat,
+        symbolBoundingData = symbolBoundingData isa Number ? symbolBoundingData : nothing,
+    )]
+
+    horizontal ? flip!(ec) : nothing
+    legend ? legend!(ec) : nothing
+
+    return ec
+end
+
+"""
+    pictorialbar(df, x, y)
+
+Creates an `EChart` pictorial bar chart from columns `x` and `y` in table `df`.
+See the primary `pictorialbar` method for full argument documentation.
+"""
+function pictorialbar(df, x::Symbol, y::Symbol;
+                      symbol::Union{String, AbstractVector} = "roundRect",
+                      symbolSize::Union{Number, AbstractVector, Nothing} = nothing,
+                      symbolRepeat::Union{Bool, Int, String, Nothing} = false,
+                      symbolBoundingData::Union{Number, Nothing} = nothing,
+                      horizontal::Bool = false,
+                      legend::Bool = false,
+                      kwargs...)
+    Tables.istable(df) || throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
+    pictorialbar(_table_col(df, x), _table_col(df, y);
+                 symbol = symbol, symbolSize = symbolSize,
+                 symbolRepeat = symbolRepeat, symbolBoundingData = symbolBoundingData,
+                 horizontal = horizontal, legend = legend, kwargs...)
+end


### PR DESCRIPTION
## Summary

- Implements `pictorialbar` — the last native ECharts series type (`pictorialBar`) not yet exposed in the library
- Accepts a single symbol string or a per-bar symbol vector, plus `symbolRepeat`, `symbolSize`, `symbolBoundingData`, and `horizontal` options
- Widens `PictorialBarSeries.symbolSize` to `Union{Number, AbstractVector, Nothing}` and `symbolBoundingData` to `Union{Number, AbstractArray, Nothing}` to match what ECharts actually accepts
- Adds docs page with three examples (basic, repeating SVG path, horizontal DataFrame variant)

## Test plan

- [ ] `pictorialbar(x, y)` renders with default `"roundRect"` symbol
- [ ] Per-bar `symbol` vector embeds correctly in per-point data dicts
- [ ] `symbolRepeat = true` + `symbolBoundingData` produces tiled icon bars
- [ ] `horizontal = true` flips axes correctly
- [ ] DataFrame method dispatches to the vector method
- [ ] Docs build cleanly (`julia --project=docs docs/make.jl`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)