### PR TITLE
Add horizonchart — single-row and multi-row horizon charts

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -63,6 +63,7 @@ makedocs(
             "charts/graph.md",
             "charts/heatmap.md",
             "charts/histogram.md",
+            "charts/horizon_chart.md",
             "charts/line.md",
             "charts/lollipop.md",
             "charts/marimekko.md",

--- a/docs/src/charts/horizon_chart.md
+++ b/docs/src/charts/horizon_chart.md
@@ -25,3 +25,34 @@ ec = horizonchart(df, :day, :dev; nbands = 4)
 title!(ec, text = "Price Deviation from 30-day MA")
 ec
 ```
+
+## Multi-row horizon chart
+
+```@example
+using ECharts, Random
+Random.seed!(42)
+# 12 monthly temperature anomaly series (different weather stations)
+n = 120
+t = collect(1:n)
+stations = ["Station $i" for i in 1:12]
+Y = [sin.(2π .* t ./ 12 .+ 0.3i) .* (1 + 0.3i) .+ 0.4 .* randn(n) for i in 1:12]
+ec = horizonchart(t, Y; names = stations, nbands = 3, row_height = 50)
+title!(ec, text = "Monthly Temperature Anomaly by Station")
+ec
+```
+
+```@example
+using ECharts, DataFrames, Random
+Random.seed!(7)
+# Cumulative returns for several assets — shared_scale makes magnitudes comparable
+n = 200
+days = string.(1:n)
+tickers = [:AAPL, :GOOG, :MSFT, :AMZN, :TSLA, :NVDA]
+df = DataFrame(day = days)
+for tk in tickers
+    df[!, tk] = cumsum(0.015 .* randn(n))
+end
+ec = horizonchart(df, :day, tickers; shared_scale = true, nbands = 3, row_height = 55)
+title!(ec, text = "Cumulative Returns — shared scale")
+ec
+```

--- a/docs/src/charts/horizon_chart.md
+++ b/docs/src/charts/horizon_chart.md
@@ -1,0 +1,27 @@
+# horizonchart
+
+```@docs
+horizonchart
+```
+
+```@example
+using ECharts
+# Simulated daily temperature anomaly (°C) over one year
+t = 1:365
+anomaly = sin.(2π .* t ./ 365) .* 3 .+ 0.8 .* randn(365)
+ec = horizonchart(collect(t), anomaly; nbands = 3)
+title!(ec, text = "Daily Temperature Anomaly (°C)",
+           subtext = "Horizon chart — 3 bands, sequential blue")
+ec
+```
+
+```@example
+using ECharts, DataFrames
+# Stock-price deviation from 30-day moving average
+days = string.(1:120)
+deviation = cumsum(0.5 .* randn(120))
+df = DataFrame(day = days, dev = deviation)
+ec = horizonchart(df, :day, :dev; nbands = 4)
+title!(ec, text = "Price Deviation from 30-day MA")
+ec
+```

--- a/docs/src/charts/horizon_chart.md
+++ b/docs/src/charts/horizon_chart.md
@@ -56,3 +56,19 @@ ec = horizonchart(df, :day, tickers; shared_scale = true, nbands = 3, row_height
 title!(ec, text = "Cumulative Returns — shared scale")
 ec
 ```
+
+```@example
+using ECharts, DataFrames, Random
+Random.seed!(99)
+# Same data with a Reds palette instead of the default Blues
+n = 200
+days = string.(1:n)
+tickers = [:AAPL, :GOOG, :MSFT, :AMZN, :TSLA, :NVDA]
+df = DataFrame(day = days)
+for tk in tickers
+    df[!, tk] = cumsum(0.015 .* randn(n))
+end
+ec = horizonchart(df, :day, tickers; palette = "Reds", shared_scale = true, nbands = 3, row_height = 55)
+title!(ec, text = "Cumulative Returns — Reds palette")
+ec
+```

--- a/src/ECharts.jl
+++ b/src/ECharts.jl
@@ -68,6 +68,7 @@ module ECharts
 	export qqplot
 	export differencearea
 	export forestplot
+	export horizonchart
 
 	export title!, yaxis!, xaxis!, yaxis2!, toolbox!, colorscheme!, flip!, seriesnames!, legend!, datazoom!, smooth!
 	export bollinger!, linreg!
@@ -169,6 +170,7 @@ module ECharts
 	include("plots/differencearea.jl")
 	include("plots/forestplot.jl")
 	include("plots/facet.jl")
+	include("plots/horizon_chart.jl")
 
 	# JSON.lower hooks replace the old makevalidjson pipeline.
 	# JSON.jl calls these automatically during serialization and recurses into

--- a/src/plots/horizon_chart.jl
+++ b/src/plots/horizon_chart.jl
@@ -13,8 +13,11 @@ horizonchart(df, x::Symbol, y::Symbol)
 
 ## Arguments
 * `nbands::Int = 3` : number of fold levels (bands)
-* `colors::Union{AbstractVector, Nothing} = nothing` : vector of `nbands` colour strings;
-  defaults to a sequential blue palette from light to dark
+* `palette::String = "Blues"` : name of a sequential palette from `colorpalettes`
+  (e.g. `"Reds"`, `"Greens"`, `"Oranges"`, `"Purples"`). `nbands` evenly-spaced
+  colours are sampled from light to dark.
+* `colors::Union{AbstractVector, Nothing} = nothing` : explicit vector of `nbands`
+  colour strings; overrides `palette` when provided
 * `legend::Bool = false` : display legend?
 * `kwargs` : varargs to set any field of resulting `EChart` struct
 
@@ -30,15 +33,25 @@ Negative values are shifted upward so the minimum maps to zero before folding.
 The y-axis maximum is fixed to `band_size` (not the full data range).
 """
 
-_horizon_palette(n::Int) = begin
-    # Sequential blues from ColorBrewer Blues (light → dark)
-    all_blues = ["#deebf7", "#c6dbef", "#9ecae1", "#6baed6", "#4292c6", "#2171b5", "#084594"]
-    idxs = round.(Int, range(1, length(all_blues), length = n))
-    [all_blues[i] for i in idxs]
+# Sample n evenly-spaced colours from a named sequential colorpalettes entry.
+# ColorBrewer sequential palettes have 3–9 swatches; we pick the largest available
+# swatch set and subsample from it.
+function _horizon_colors(palette::String, n::Int)
+    haskey(colorpalettes, palette) ||
+        throw(ArgumentError("palette \"$palette\" not found in colorpalettes"))
+    pal = colorpalettes[palette]
+    # Keys are like "3","4",…,"9","type" — keep only numeric ones
+    numeric_keys = [k for k in keys(pal) if all(isdigit, k)]
+    isempty(numeric_keys) && throw(ArgumentError("palette \"$palette\" has no numeric swatch keys"))
+    max_key = string(maximum(parse(Int, k) for k in numeric_keys))
+    all_colors = pal[max_key]
+    idxs = round.(Int, range(1, length(all_colors); length = n))
+    [all_colors[i] for i in idxs]
 end
 
 function horizonchart(x::AbstractVector, y::AbstractVector{<:Real};
                       nbands::Int = 3,
+                      palette::String = "Blues",
                       colors::Union{AbstractVector, Nothing} = nothing,
                       legend::Bool = false,
                       kwargs...)
@@ -54,7 +67,7 @@ function horizonchart(x::AbstractVector, y::AbstractVector{<:Real};
     ymax > 0 || throw(ArgumentError("all values are identical; cannot build a horizon chart"))
 
     band_size = ymax / nbands
-    clrs = isnothing(colors) ? _horizon_palette(nbands) : colors
+    clrs = isnothing(colors) ? _horizon_colors(palette, nbands) : colors
     length(clrs) == nbands ||
         throw(ArgumentError("length(colors) must equal nbands (got $(length(clrs)), need $nbands)"))
 
@@ -93,13 +106,15 @@ See the primary `horizonchart` method for full argument documentation.
 """
 function horizonchart(df, x::Symbol, y::Symbol;
                       nbands::Int = 3,
+                      palette::String = "Blues",
                       colors::Union{AbstractVector, Nothing} = nothing,
                       legend::Bool = false,
                       kwargs...)
     Tables.istable(df) ||
         throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
     ec = horizonchart(_table_col(df, x), _table_col(df, y);
-                      nbands = nbands, colors = colors, legend = legend, kwargs...)
+                      nbands = nbands, palette = palette, colors = colors,
+                      legend = legend, kwargs...)
     xaxis!(ec, name = string(x))
     yaxis!(ec, name = string(y))
     return ec
@@ -124,8 +139,10 @@ horizonchart(df, x::Symbol, ys::AbstractVector{Symbol}; ...)
 * `names::Union{AbstractVector, Nothing} = nothing` : row labels; defaults to
   `"Series 1"`, `"Series 2"`, …
 * `nbands::Int = 3` : number of fold levels per row
-* `colors::Union{AbstractVector, Nothing} = nothing` : `nbands` colour strings shared
-  across all rows; defaults to sequential blues
+* `palette::String = "Blues"` : named sequential palette from `colorpalettes`;
+  `nbands` colours are sampled light-to-dark and shared across all rows
+* `colors::Union{AbstractVector, Nothing} = nothing` : explicit colour override;
+  takes precedence over `palette` when provided
 * `row_height::Int = 60` : height of each row in pixels
 * `shared_scale::Bool = false` : if `true`, all rows use the same `band_size`
   (the global maximum ÷ `nbands`); if `false` (default) each row is scaled
@@ -142,6 +159,7 @@ function horizonchart(x::AbstractVector,
                       Y::AbstractVector{<:AbstractVector{<:Real}};
                       names::Union{AbstractVector, Nothing} = nothing,
                       nbands::Int = 3,
+                      palette::String = "Blues",
                       colors::Union{AbstractVector, Nothing} = nothing,
                       shared_scale::Bool = false,
                       row_height::Int = 60,
@@ -157,7 +175,7 @@ function horizonchart(x::AbstractVector,
     length(row_names) == n ||
         throw(ArgumentError("length(names) must equal number of series"))
 
-    clrs = isnothing(colors) ? _horizon_palette(nbands) : colors
+    clrs = isnothing(colors) ? _horizon_colors(palette, nbands) : colors
     length(clrs) == nbands ||
         throw(ArgumentError("length(colors) must equal nbands"))
 
@@ -281,7 +299,7 @@ See the `horizonchart(x, Y::Vector{Vector})` method for full documentation.
 function horizonchart(x::AbstractVector,
                       Y::AbstractMatrix{<:Real};
                       kwargs...)
-    horizonchart(x, [Y[:, j] for j in 1:size(Y, 2)]; kwargs...)
+    horizonchart(x, [Y[:, j] for j in axes(Y, 2)]; kwargs...)
 end
 
 """
@@ -294,6 +312,7 @@ See the `horizonchart(x, Y::Vector{Vector})` method for full documentation.
 function horizonchart(df, x::Symbol, ys::AbstractVector{Symbol};
                       names::Union{AbstractVector, Nothing} = nothing,
                       nbands::Int = 3,
+                      palette::String = "Blues",
                       colors::Union{AbstractVector, Nothing} = nothing,
                       shared_scale::Bool = false,
                       row_height::Int = 60,
@@ -304,6 +323,6 @@ function horizonchart(df, x::Symbol, ys::AbstractVector{Symbol};
     Yvec = [_table_col(df, s) for s in ys]
     nm   = isnothing(names) ? string.(ys) : names
     horizonchart(xvec, Yvec;
-                 names = nm, nbands = nbands, colors = colors,
+                 names = nm, nbands = nbands, palette = palette, colors = colors,
                  shared_scale = shared_scale, row_height = row_height, kwargs...)
 end

--- a/src/plots/horizon_chart.jl
+++ b/src/plots/horizon_chart.jl
@@ -178,53 +178,67 @@ function horizonchart(x::AbstractVector,
         band_sizes .= global_bs
     end
 
-    # Layout: percentage-based, one row per series
-    lm   = 12.0   # left margin — room for row labels
-    rm   = 2.0
-    tm   = 1.0
-    bm   = 6.0    # bottom margin — room for x-axis ticks on last row
-    rgap = 0.5    # tiny gap between rows
+    # ── Pixel-exact layout ───────────────────────────────────────────────────
+    # All positions in pixels so rows align perfectly regardless of label length.
+    canvas_w  = 800
+    lm_px     = 110   # fixed left margin — labels are right-aligned here
+    rm_px     = 10
+    title_px  = 40    # reserved for an optional title above the rows
+    bottom_px = 30    # space for x-axis ticks on the last row
+    row_gap   = 1     # 1 px gap between rows
 
-    row_h_pct = (100.0 - tm - bm - (n - 1) * rgap) / n
+    canvas_h  = title_px + n * row_height + bottom_px
 
-    grids  = Grid[]
-    xaxes  = Axis[]
-    yaxes  = Axis[]
+    grids   = Grid[]
+    xaxes   = Axis[]
+    yaxes   = Axis[]
     seriess = AbstractEChartSeries[]
+    labels  = GraphicElement[]
 
     for i in 1:n
-        idx   = i - 1
-        gt    = tm + (i - 1) * (row_h_pct + rgap)
-        bs    = band_sizes[i]
-        show_x = i == n   # x-axis labels only on last row
+        idx    = i - 1
+        row_top = title_px + (i - 1) * row_height
+        bs      = band_sizes[i]
+        show_x  = i == n
 
         push!(grids, Grid(
-            left         = "$(round(lm; digits=1))%",
-            top          = "$(round(gt; digits=1))%",
-            width        = "$(round(100.0 - lm - rm; digits=1))%",
-            height       = "$(round(row_h_pct; digits=1))%",
-            containLabel = false,
+            left   = lm_px,
+            top    = row_top,
+            width  = canvas_w - lm_px - rm_px,
+            height = row_height - row_gap,
         ))
 
         push!(xaxes, Axis(
             _type     = x_type,
             gridIndex = idx,
             show      = show_x,
-            axisLabel = show_x ? AxisLabel() : AxisLabel(show = false),
+            axisLabel = show_x ? AxisLabel(fontSize = 10) : AxisLabel(show = false),
             splitLine = SplitLine(show = false),
+            axisTick  = AxisTick(show = show_x),
         ))
 
         push!(yaxes, Axis(
             _type     = "value",
             gridIndex = idx,
             min       = 0,
-            name      = row_names[i],
-            nameLocation = "middle",
-            nameRotate   = 0,
-            nameGap      = round(Int, lm * 6),   # push label into left margin
-            axisLabel    = AxisLabel(show = false),
-            splitLine    = SplitLine(show = false),
-            axisTick     = AxisTick(show = false),
+            axisLabel = AxisLabel(show = false),
+            splitLine = SplitLine(show = false),
+            axisTick  = AxisTick(show = false),
+            axisLine  = AxisLine(show = false),
+        ))
+
+        # Right-aligned graphic text label — all anchored at the same x pixel
+        push!(labels, GraphicElement(
+            _type = "text",
+            left  = lm_px - 6,
+            top   = row_top + div(row_height, 2),
+            style = GraphicStyle(
+                text              = row_names[i],
+                textAlign         = "right",
+                textVerticalAlign = "middle",
+                fill              = "#555",
+                font              = "12px sans-serif",
+            ),
         ))
 
         for k in 0:nbands-1
@@ -244,13 +258,14 @@ function horizonchart(x::AbstractVector,
     end
 
     ec = newplot(kwargs, ec_charttype = "horizonchart")
-    ec.grid   = grids
-    ec.xAxis  = xaxes
-    ec.yAxis  = yaxes
-    ec.series = seriess
-    ec.legend = nothing
-    ec.ec_height = n * row_height + 60
-    ec.ec_width  = 800
+    ec.grid    = grids
+    ec.xAxis   = xaxes
+    ec.yAxis   = yaxes
+    ec.series  = seriess
+    ec.legend  = nothing
+    ec.graphic = Graphic(labels)
+    ec.ec_height = canvas_h
+    ec.ec_width  = canvas_w
 
     return ec
 end

--- a/src/plots/horizon_chart.jl
+++ b/src/plots/horizon_chart.jl
@@ -1,0 +1,106 @@
+"""
+    horizonchart(x, y)
+
+Creates an `EChart` horizon chart — a compact time-series visualisation that folds a tall
+area chart into `nbands` overlapping bands, each shaded progressively darker to encode
+magnitude. This allows many series to be compared in a small vertical space.
+
+## Methods
+```julia
+horizonchart(x::AbstractVector, y::AbstractVector{<:Real})
+horizonchart(df, x::Symbol, y::Symbol)
+```
+
+## Arguments
+* `nbands::Int = 3` : number of fold levels (bands)
+* `colors::Union{AbstractVector, Nothing} = nothing` : vector of `nbands` colour strings;
+  defaults to a sequential blue palette from light to dark
+* `legend::Bool = false` : display legend?
+* `kwargs` : varargs to set any field of resulting `EChart` struct
+
+## Notes
+
+The data range is divided into `nbands` equal intervals of height `band_size = max / nbands`.
+Band *k* (0-indexed) displays the portion of the signal in `[k·band_size, (k+1)·band_size]`
+folded back to `[0, band_size]`. Higher bands are drawn on top with a darker colour,
+creating the illusion of a taller chart compressed into a single row.
+
+Negative values are shifted upward so the minimum maps to zero before folding.
+
+The y-axis maximum is fixed to `band_size` (not the full data range).
+"""
+
+_horizon_palette(n::Int) = begin
+    # Sequential blues from ColorBrewer Blues (light → dark)
+    all_blues = ["#deebf7", "#c6dbef", "#9ecae1", "#6baed6", "#4292c6", "#2171b5", "#084594"]
+    idxs = round.(Int, range(1, length(all_blues), length = n))
+    [all_blues[i] for i in idxs]
+end
+
+function horizonchart(x::AbstractVector, y::AbstractVector{<:Real};
+                      nbands::Int = 3,
+                      colors::Union{AbstractVector, Nothing} = nothing,
+                      legend::Bool = false,
+                      kwargs...)
+
+    nbands >= 1 || throw(ArgumentError("nbands must be ≥ 1"))
+    length(x) == length(y) ||
+        throw(ArgumentError("x and y must have the same length"))
+
+    # Shift to non-negative
+    ymin = minimum(y)
+    y_shifted = ymin < 0 ? collect(Float64, y .- ymin) : collect(Float64, y)
+    ymax = maximum(y_shifted)
+    ymax > 0 || throw(ArgumentError("all values are identical; cannot build a horizon chart"))
+
+    band_size = ymax / nbands
+    clrs = isnothing(colors) ? _horizon_palette(nbands) : colors
+    length(clrs) == nbands ||
+        throw(ArgumentError("length(colors) must equal nbands (got $(length(clrs)), need $nbands)"))
+
+    x_type = eltype(x) <: Real ? "value" : "category"
+
+    series_list = XYSeries[]
+    for k in 0:nbands-1
+        band_y = [max(0.0, min(y_shifted[i] - k * band_size, band_size))
+                  for i in eachindex(y_shifted)]
+        push!(series_list, XYSeries(
+            name       = "Band $(k + 1)",
+            _type      = "line",
+            data       = arrayofarray(x, band_y),
+            areaStyle  = AreaStyle(color = clrs[k + 1]),
+            lineStyle  = LineStyle(opacity = 0),
+            showSymbol = false,
+        ))
+    end
+
+    ec = newplot(kwargs, ec_charttype = "horizonchart")
+    ec.xAxis  = [Axis(_type = x_type)]
+    ec.yAxis  = [Axis(_type = "value", min = 0, max = band_size)]
+    ec.series = series_list
+
+    legend ? legend!(ec) : nothing
+
+    return ec
+end
+
+"""
+    horizonchart(df, x, y)
+
+Creates an `EChart` horizon chart from columns `x` and `y` in table `df`.
+Axis labels are set from the column names.
+See the primary `horizonchart` method for full argument documentation.
+"""
+function horizonchart(df, x::Symbol, y::Symbol;
+                      nbands::Int = 3,
+                      colors::Union{AbstractVector, Nothing} = nothing,
+                      legend::Bool = false,
+                      kwargs...)
+    Tables.istable(df) ||
+        throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
+    ec = horizonchart(_table_col(df, x), _table_col(df, y);
+                      nbands = nbands, colors = colors, legend = legend, kwargs...)
+    xaxis!(ec, name = string(x))
+    yaxis!(ec, name = string(y))
+    return ec
+end

--- a/src/plots/horizon_chart.jl
+++ b/src/plots/horizon_chart.jl
@@ -104,3 +104,189 @@ function horizonchart(df, x::Symbol, y::Symbol;
     yaxis!(ec, name = string(y))
     return ec
 end
+
+"""
+    horizonchart(x, Y; names)
+
+Creates a multi-row `EChart` horizon chart — one compact row per series, all sharing
+the same x-axis. This matches the classic horizon chart as shown in academic literature
+and tools like Vega-Lite: many time series stacked vertically in a small space, each
+independently scaled so differences within a series are visible regardless of magnitude.
+
+## Methods
+```julia
+horizonchart(x::AbstractVector, Y::AbstractMatrix{<:Real}; names, ...)
+horizonchart(x::AbstractVector, Y::AbstractVector{<:AbstractVector{<:Real}}; names, ...)
+horizonchart(df, x::Symbol, ys::AbstractVector{Symbol}; ...)
+```
+
+## Arguments
+* `names::Union{AbstractVector, Nothing} = nothing` : row labels; defaults to
+  `"Series 1"`, `"Series 2"`, …
+* `nbands::Int = 3` : number of fold levels per row
+* `colors::Union{AbstractVector, Nothing} = nothing` : `nbands` colour strings shared
+  across all rows; defaults to sequential blues
+* `row_height::Int = 60` : height of each row in pixels
+* `shared_scale::Bool = false` : if `true`, all rows use the same `band_size`
+  (the global maximum ÷ `nbands`); if `false` (default) each row is scaled
+  independently so its own range fills the band height
+* `kwargs` : varargs to set any field of the resulting `EChart` struct
+
+## Notes
+
+Each row is an independent grid with its own x/y axes. The x-axis is shown only on
+the bottom row. Row labels appear on the left y-axis of each row. Total chart height
+is `n_series × row_height + bottom_margin` pixels.
+"""
+function horizonchart(x::AbstractVector,
+                      Y::AbstractVector{<:AbstractVector{<:Real}};
+                      names::Union{AbstractVector, Nothing} = nothing,
+                      nbands::Int = 3,
+                      colors::Union{AbstractVector, Nothing} = nothing,
+                      shared_scale::Bool = false,
+                      row_height::Int = 60,
+                      kwargs...)
+
+    n = length(Y)
+    n >= 2 || throw(ArgumentError("multi-row horizonchart requires at least 2 series"))
+    all(length(yi) == length(x) for yi in Y) ||
+        throw(ArgumentError("every series in Y must have the same length as x"))
+    nbands >= 1 || throw(ArgumentError("nbands must be ≥ 1"))
+
+    row_names = isnothing(names) ? ["Series $i" for i in 1:n] : collect(names)
+    length(row_names) == n ||
+        throw(ArgumentError("length(names) must equal number of series"))
+
+    clrs = isnothing(colors) ? _horizon_palette(nbands) : colors
+    length(clrs) == nbands ||
+        throw(ArgumentError("length(colors) must equal nbands"))
+
+    x_type = eltype(x) <: Real ? "value" : "category"
+
+    # Shift each series to non-negative, compute per-row band_size
+    y_shifted = Vector{Vector{Float64}}(undef, n)
+    band_sizes = Vector{Float64}(undef, n)
+    for i in 1:n
+        ymin = minimum(Y[i])
+        ys   = ymin < 0 ? collect(Float64, Y[i] .- ymin) : collect(Float64, Y[i])
+        y_shifted[i]  = ys
+        band_sizes[i] = maximum(ys) / nbands
+    end
+
+    if shared_scale
+        global_bs = maximum(band_sizes)
+        band_sizes .= global_bs
+    end
+
+    # Layout: percentage-based, one row per series
+    lm   = 12.0   # left margin — room for row labels
+    rm   = 2.0
+    tm   = 1.0
+    bm   = 6.0    # bottom margin — room for x-axis ticks on last row
+    rgap = 0.5    # tiny gap between rows
+
+    row_h_pct = (100.0 - tm - bm - (n - 1) * rgap) / n
+
+    grids  = Grid[]
+    xaxes  = Axis[]
+    yaxes  = Axis[]
+    seriess = AbstractEChartSeries[]
+
+    for i in 1:n
+        idx   = i - 1
+        gt    = tm + (i - 1) * (row_h_pct + rgap)
+        bs    = band_sizes[i]
+        show_x = i == n   # x-axis labels only on last row
+
+        push!(grids, Grid(
+            left         = "$(round(lm; digits=1))%",
+            top          = "$(round(gt; digits=1))%",
+            width        = "$(round(100.0 - lm - rm; digits=1))%",
+            height       = "$(round(row_h_pct; digits=1))%",
+            containLabel = false,
+        ))
+
+        push!(xaxes, Axis(
+            _type     = x_type,
+            gridIndex = idx,
+            show      = show_x,
+            axisLabel = show_x ? AxisLabel() : AxisLabel(show = false),
+            splitLine = SplitLine(show = false),
+        ))
+
+        push!(yaxes, Axis(
+            _type     = "value",
+            gridIndex = idx,
+            min       = 0,
+            name      = row_names[i],
+            nameLocation = "middle",
+            nameRotate   = 0,
+            nameGap      = round(Int, lm * 6),   # push label into left margin
+            axisLabel    = AxisLabel(show = false),
+            splitLine    = SplitLine(show = false),
+            axisTick     = AxisTick(show = false),
+        ))
+
+        for k in 0:nbands-1
+            band_y = [max(0.0, min(y_shifted[i][j] - k * bs, bs))
+                      for j in eachindex(y_shifted[i])]
+            push!(seriess, XYSeries(
+                name       = i == 1 ? "Band $(k+1)" : nothing,
+                _type      = "line",
+                data       = arrayofarray(x, band_y),
+                xAxisIndex = idx,
+                yAxisIndex = idx,
+                areaStyle  = AreaStyle(color = clrs[k+1]),
+                lineStyle  = LineStyle(opacity = 0),
+                showSymbol = false,
+            ))
+        end
+    end
+
+    ec = newplot(kwargs, ec_charttype = "horizonchart")
+    ec.grid   = grids
+    ec.xAxis  = xaxes
+    ec.yAxis  = yaxes
+    ec.series = seriess
+    ec.legend = nothing
+    ec.ec_height = n * row_height + 60
+    ec.ec_width  = 800
+
+    return ec
+end
+
+"""
+    horizonchart(x, Y::AbstractMatrix; names, ...)
+
+Multi-row horizon chart from a matrix where each column is one series.
+See the `horizonchart(x, Y::Vector{Vector})` method for full documentation.
+"""
+function horizonchart(x::AbstractVector,
+                      Y::AbstractMatrix{<:Real};
+                      kwargs...)
+    horizonchart(x, [Y[:, j] for j in 1:size(Y, 2)]; kwargs...)
+end
+
+"""
+    horizonchart(df, x, ys; ...)
+
+Multi-row horizon chart from table `df`, where `ys` is a vector of column symbols —
+one row per column.
+See the `horizonchart(x, Y::Vector{Vector})` method for full documentation.
+"""
+function horizonchart(df, x::Symbol, ys::AbstractVector{Symbol};
+                      names::Union{AbstractVector, Nothing} = nothing,
+                      nbands::Int = 3,
+                      colors::Union{AbstractVector, Nothing} = nothing,
+                      shared_scale::Bool = false,
+                      row_height::Int = 60,
+                      kwargs...)
+    Tables.istable(df) ||
+        throw(ArgumentError("first argument must be a Tables.jl-compatible table"))
+    xvec = _table_col(df, x)
+    Yvec = [_table_col(df, s) for s in ys]
+    nm   = isnothing(names) ? string.(ys) : names
+    horizonchart(xvec, Yvec;
+                 names = nm, nbands = nbands, colors = colors,
+                 shared_scale = shared_scale, row_height = row_height, kwargs...)
+end

--- a/src/plots/horizon_chart.jl
+++ b/src/plots/horizon_chart.jl
@@ -76,7 +76,7 @@ function horizonchart(x::AbstractVector, y::AbstractVector{<:Real};
 
     ec = newplot(kwargs, ec_charttype = "horizonchart")
     ec.xAxis  = [Axis(_type = x_type)]
-    ec.yAxis  = [Axis(_type = "value", min = 0, max = band_size)]
+    ec.yAxis  = [Axis(_type = "value", min = 0)]
     ec.series = series_list
 
     legend ? legend!(ec) : nothing

--- a/src/plots/horizon_chart.jl
+++ b/src/plots/horizon_chart.jl
@@ -227,13 +227,15 @@ function horizonchart(x::AbstractVector,
             axisLine  = AxisLine(show = false),
         ))
 
-        # Right-aligned graphic text label — all anchored at the same x pixel
+        # Right-aligned graphic text label.
+        # style.x/style.y set the anchor point; textAlign="right" means text
+        # extends leftward from that anchor, keeping all labels flush-right.
         push!(labels, GraphicElement(
             _type = "text",
-            left  = lm_px - 6,
-            top   = row_top + div(row_height, 2),
             style = GraphicStyle(
                 text              = row_names[i],
+                x                 = lm_px - 6,
+                y                 = row_top + div(row_height, 2),
                 textAlign         = "right",
                 textVerticalAlign = "middle",
                 fill              = "#555",

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -710,3 +710,40 @@ result_qq2eq = qqplot(randn(50), randn(50))
 # qqplot — two-sample too few elements raises error
 @test_throws ArgumentError qqplot([1.0], randn(50))
 @test_throws ArgumentError qqplot(randn(50), [1.0])
+
+# horizonchart — basic numeric x-axis
+hc_x = collect(1:100)
+hc_y = sin.(range(0, 4π, length = 100)) .* 5 .+ 3.0
+result_hc = horizonchart(hc_x, hc_y)
+@test typeof(result_hc) == EChart
+@test result_hc.ec_charttype == "horizonchart"
+@test length(result_hc.series) == 3      # default nbands = 3
+@test result_hc.yAxis[1].min == 0
+@test result_hc.xAxis[1]._type == "value"
+@test all(s._type == "line" for s in result_hc.series)
+
+# horizonchart — string x-axis becomes category
+hc_cats = string.(1:50)
+hc_y2   = abs.(randn(50)) .* 4
+result_hc_cat = horizonchart(hc_cats, hc_y2; nbands = 2)
+@test result_hc_cat.xAxis[1]._type == "category"
+@test length(result_hc_cat.series) == 2
+
+# horizonchart — negative values shift without error
+result_hc_neg = horizonchart(hc_x, hc_y .- 10.0)
+@test typeof(result_hc_neg) == EChart
+
+# horizonchart — custom colors
+result_hc_col = horizonchart(hc_x, hc_y; nbands = 2, colors = ["#ffffcc", "#d9f0a3"])
+@test typeof(result_hc_col) == EChart
+
+# horizonchart — color length mismatch raises error
+@test_throws ArgumentError horizonchart(hc_x, hc_y; nbands = 3, colors = ["#aaa", "#bbb"])
+
+# horizonchart — table method
+using DataFrames
+hc_df = DataFrame(t = hc_x, v = hc_y)
+result_hc_df = horizonchart(hc_df, :t, :v)
+@test typeof(result_hc_df) == EChart
+@test result_hc_df.xAxis[1].name == "t"
+@test result_hc_df.yAxis[1].name == "v"


### PR DESCRIPTION
## Summary

- Adds `horizonchart` for compact time-series visualisation using the horizon chart technique (folded area chart with progressive band shading)
- Single-series method: `horizonchart(x, y)` and `horizonchart(df, x, y)`
- Multi-row method: `horizonchart(x, Y; names)` and `horizonchart(df, x, ys)` — one compact row per series sharing a common x-axis, matching the classic horizon chart format
- `palette` kwarg (default `"Blues"`) samples `nbands` colors from any `colorpalettes` sequential scheme (e.g. `"Reds"`, `"Greens"`); explicit `colors` vector overrides it
- Multi-row layout uses pixel-exact positioning and `Graphic` text elements for flush-right row labels that align regardless of label length or font metrics
- Docs page with 5 rendered examples including palette comparison

## Test plan

- [ ] Build docs: `julia --project=docs docs/make.jl` — all 5 `horizonchart` examples render without errors
- [ ] Single-row: numeric and category x-axes both work
- [ ] Multi-row: `names`, `shared_scale`, `row_height`, `palette` kwargs all work
- [ ] `palette` error raised for unknown palette name
- [ ] `colors` length mismatch raises error
- [ ] Tests in `test/plots.jl` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)